### PR TITLE
Improve schedule review/export UX and normalize term/id handling

### DIFF
--- a/app/assets/css/global.css
+++ b/app/assets/css/global.css
@@ -19,7 +19,7 @@
 
   --color-focus-ring: #0369a1;
   --color-text-danger: #b91c1c;
-  --color-example-text: #c8cace; /* slightly lighter gray for example/placeholder text */
+  --color-example-text: #cfcfcf; /* slightly lighter gray for example/placeholder text */
 }
 
 html,

--- a/app/assets/css/global.css
+++ b/app/assets/css/global.css
@@ -211,6 +211,65 @@ button:disabled {
   gap: 20px;
 }
 
+/* Shared schedule DataTable layout used in admin schedule pages */
+.schedule-table {
+  width: 100%;
+  min-width: 0;
+}
+
+.schedule-table .p-datatable-table-container {
+  overflow: hidden;
+}
+
+.schedule-table .p-datatable-table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.schedule-table .p-datatable-thead > tr > th,
+.schedule-table .p-datatable-tbody > tr > td {
+  padding: 0.45rem 0.55rem;
+  font-size: 0.74rem;
+  line-height: 1.25;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  vertical-align: top;
+}
+
+.schedule-table .p-datatable-tbody > tr > td {
+  height: 4.15rem;
+}
+
+.schedule-table .p-column-header-content {
+  align-items: flex-start;
+  gap: 0.3rem;
+}
+
+.schedule-table .p-button {
+  padding: 0.35rem 0.55rem;
+  font-size: 0.72rem;
+}
+
+.schedule-table .p-inputtext {
+  min-width: 0;
+  font-size: 0.74rem;
+  padding: 0.45rem 0.55rem;
+}
+
+.schedule-table--trace .p-datatable-thead > tr > th,
+.schedule-table--trace .p-datatable-tbody > tr > td,
+.schedule-table--issues .p-datatable-thead > tr > th,
+.schedule-table--issues .p-datatable-tbody > tr > td {
+  font-size: 0.7rem;
+}
+
+.schedule-table-empty {
+  padding: 1rem;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
 @media (max-width: 640px) {
   .site-top-bar {
     padding: 0.75rem;

--- a/app/components/ScheduleCellPreview.vue
+++ b/app/components/ScheduleCellPreview.vue
@@ -1,0 +1,126 @@
+<template>
+  <div class="schedule-cell-preview">
+    <div
+      class="schedule-cell-preview__text"
+      :title="plainText"
+      :style="{ WebkitLineClamp: String(maxLines) }"
+    >
+      {{ plainText }}
+    </div>
+
+    <button
+      v-if="canExpand"
+      type="button"
+      class="schedule-cell-preview__button"
+      :aria-label="`Open full ${title.toLowerCase()}`"
+      @click="dialogVisible = true"
+    >
+      <i class="pi pi-expand" aria-hidden="true" />
+    </button>
+
+    <Dialog
+      v-model:visible="dialogVisible"
+      modal
+      :header="title"
+      class="schedule-cell-preview__dialog"
+      :style="{ width: 'min(42rem, calc(100vw - 2rem))' }"
+    >
+      <div class="schedule-cell-preview__dialog-text">
+        {{ plainText }}
+      </div>
+    </Dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    value?: string | number | null
+    title?: string
+    maxLines?: number
+    expandThreshold?: number
+  }>(),
+  {
+    value: '',
+    title: 'Cell Details',
+    maxLines: 2,
+    expandThreshold: 32,
+  },
+)
+
+const dialogVisible = ref(false)
+
+const plainText = computed(() => {
+  if (props.value === null || props.value === undefined || props.value === '') {
+    return 'N/A'
+  }
+
+  return String(props.value)
+})
+
+const canExpand = computed(() => {
+  return (
+    plainText.value.length > props.expandThreshold ||
+    plainText.value.includes('\n') ||
+    plainText.value.includes('; ') ||
+    plainText.value.includes(' | ')
+  )
+})
+</script>
+
+<style scoped>
+.schedule-cell-preview {
+  position: relative;
+  min-height: 2.6rem;
+  padding-right: 1.55rem;
+}
+
+.schedule-cell-preview__text {
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  line-height: 1.25;
+}
+
+.schedule-cell-preview__button {
+  position: absolute;
+  top: 0.05rem;
+  right: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.15rem;
+  height: 1.15rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.schedule-cell-preview__button:hover {
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+.schedule-cell-preview__button:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
+}
+
+.schedule-cell-preview__button .pi {
+  font-size: 0.7rem;
+}
+
+.schedule-cell-preview__dialog-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  line-height: 1.5;
+}
+</style>

--- a/app/pages/admin/schedule_run.vue
+++ b/app/pages/admin/schedule_run.vue
@@ -1354,51 +1354,6 @@ onMounted(async () => {
   margin: 0;
 }
 
-.schedule-table-empty {
-  padding: 1rem;
-  text-align: center;
-  color: var(--color-text-muted);
-}
-
-.schedule-table {
-  width: 100%;
-  min-width: 0;
-}
-
-.schedule-table :deep(.p-datatable-table-container) {
-  overflow: hidden;
-}
-
-.schedule-table :deep(.p-datatable-table) {
-  width: 100%;
-  table-layout: fixed;
-}
-
-.schedule-table :deep(.p-datatable-thead > tr > th),
-.schedule-table :deep(.p-datatable-tbody > tr > td) {
-  padding: 0.45rem 0.55rem;
-  font-size: 0.74rem;
-  line-height: 1.25;
-  white-space: normal;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-  vertical-align: top;
-}
-
-.schedule-table :deep(.p-datatable-tbody > tr > td) {
-  height: 4.15rem;
-}
-
-.schedule-table :deep(.p-column-header-content) {
-  align-items: flex-start;
-  gap: 0.3rem;
-}
-
-.schedule-table--issues :deep(.p-datatable-thead > tr > th),
-.schedule-table--issues :deep(.p-datatable-tbody > tr > td) {
-  font-size: 0.7rem;
-}
-
 @media (max-width: 1080px) {
   .schedule-admin-columns {
     grid-template-columns: 1fr;

--- a/app/pages/admin/schedule_run.vue
+++ b/app/pages/admin/schedule_run.vue
@@ -179,26 +179,73 @@
               <DataTable
                 :value="enrichedRunRows"
                 stripedRows
-                scrollable
                 showGridlines
-                tableStyle="min-width: 75rem"
-                class="schedule-table"
+                class="schedule-table schedule-table--main"
               >
-                <Column field="department" header="Dept" sortable />
-                <Column field="courseNumber" header="Course" sortable />
-                <Column field="section" header="Section" sortable>
+                <Column field="department" header="Dept" sortable>
                   <template #body="{ data }">
-                    {{ data.section || 'N/A' }}
+                    <ScheduleCellPreview
+                      :value="data.department"
+                      title="Department"
+                    />
                   </template>
                 </Column>
-                <Column field="courseTitle" header="Title" sortable />
-                <Column field="instructorName" header="Instructor" sortable />
-                <Column field="timeLabel" header="Time" sortable />
-                <Column field="building" header="Building" sortable />
-                <Column field="roomLabel" header="Room" sortable />
+                <Column field="courseNumber" header="Course" sortable>
+                  <template #body="{ data }">
+                    <ScheduleCellPreview
+                      :value="data.courseNumber"
+                      title="Course"
+                    />
+                  </template>
+                </Column>
+                <Column field="section" header="Section" sortable>
+                  <template #body="{ data }">
+                    <ScheduleCellPreview
+                      :value="data.section || 'N/A'"
+                      title="Section"
+                    />
+                  </template>
+                </Column>
+                <Column field="courseTitle" header="Title" sortable>
+                  <template #body="{ data }">
+                    <ScheduleCellPreview
+                      :value="data.courseTitle"
+                      title="Course Title"
+                    />
+                  </template>
+                </Column>
+                <Column field="instructorName" header="Instructor" sortable>
+                  <template #body="{ data }">
+                    <ScheduleCellPreview
+                      :value="data.instructorName"
+                      title="Instructor"
+                    />
+                  </template>
+                </Column>
+                <Column field="timeLabel" header="Time" sortable>
+                  <template #body="{ data }">
+                    <ScheduleCellPreview :value="data.timeLabel" title="Time" />
+                  </template>
+                </Column>
+                <Column field="building" header="Building" sortable>
+                  <template #body="{ data }">
+                    <ScheduleCellPreview
+                      :value="data.building"
+                      title="Building"
+                    />
+                  </template>
+                </Column>
+                <Column field="roomLabel" header="Room" sortable>
+                  <template #body="{ data }">
+                    <ScheduleCellPreview :value="data.roomLabel" title="Room" />
+                  </template>
+                </Column>
                 <Column field="enrollment" header="Enroll" sortable>
                   <template #body="{ data }">
-                    {{ data.enrollment ?? 'N/A' }}
+                    <ScheduleCellPreview
+                      :value="data.enrollment ?? 'N/A'"
+                      title="Enrollment"
+                    />
                   </template>
                 </Column>
               </DataTable>
@@ -221,21 +268,56 @@
                 <DataTable
                   :value="conflictRows"
                   stripedRows
-                  scrollable
                   showGridlines
-                  tableStyle="min-width: 65rem"
+                  class="schedule-table schedule-table--issues"
                 >
                   <template #empty>
                     <div class="schedule-table-empty">
                       No conflicts returned.
                     </div>
                   </template>
-                  <Column field="courseId" header="Course" sortable />
-                  <Column field="instructor" header="Instructor" sortable />
-                  <Column field="room" header="Room" sortable />
-                  <Column field="time" header="Time" sortable />
-                  <Column field="issueType" header="Issue Type" sortable />
-                  <Column field="reason" header="Reason" />
+                  <Column field="courseLabel" header="Course" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.courseLabel"
+                        title="Course"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="instructor" header="Instructor" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.instructor"
+                        title="Instructor"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="room" header="Room" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview :value="data.room" title="Room" />
+                    </template>
+                  </Column>
+                  <Column field="time" header="Time" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview :value="data.time" title="Time" />
+                    </template>
+                  </Column>
+                  <Column field="issueType" header="Issue Type" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.issueType"
+                        title="Issue Type"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="reason" header="Reason">
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.reason"
+                        title="Reason"
+                      />
+                    </template>
+                  </Column>
                 </DataTable>
               </div>
 
@@ -244,21 +326,56 @@
                 <DataTable
                   :value="nearHardFlagRows"
                   stripedRows
-                  scrollable
                   showGridlines
-                  tableStyle="min-width: 65rem"
+                  class="schedule-table schedule-table--issues"
                 >
                   <template #empty>
                     <div class="schedule-table-empty">
                       No near-hard flags returned.
                     </div>
                   </template>
-                  <Column field="courseId" header="Course" sortable />
-                  <Column field="instructor" header="Instructor" sortable />
-                  <Column field="room" header="Room" sortable />
-                  <Column field="time" header="Time" sortable />
-                  <Column field="issueType" header="Issue Type" sortable />
-                  <Column field="reason" header="Reason" />
+                  <Column field="courseLabel" header="Course" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.courseLabel"
+                        title="Course"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="instructor" header="Instructor" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.instructor"
+                        title="Instructor"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="room" header="Room" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview :value="data.room" title="Room" />
+                    </template>
+                  </Column>
+                  <Column field="time" header="Time" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview :value="data.time" title="Time" />
+                    </template>
+                  </Column>
+                  <Column field="issueType" header="Issue Type" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.issueType"
+                        title="Issue Type"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="reason" header="Reason">
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.reason"
+                        title="Reason"
+                      />
+                    </template>
+                  </Column>
                 </DataTable>
               </div>
             </div>
@@ -434,6 +551,13 @@ type ScheduleSaveResponse = {
   schedules: SavedScheduleDetails[]
 }
 
+type ScheduleTermRunsResponse = {
+  ok: true
+  term: string
+  count: number
+  schedules: SavedScheduleDetails[]
+}
+
 const term = ref('')
 const selectedTerm = ref('')
 const termSuggestions = ref<string[]>([])
@@ -501,13 +625,18 @@ const enrichedRunRows = computed(() =>
 )
 
 const conflictRows = computed(() =>
-  buildIssueTableRows(runResult.value?.conflicts ?? [], enrichedRunRows.value),
+  buildIssueTableRows(
+    runResult.value?.conflicts ?? [],
+    enrichedRunRows.value,
+    lookups.value,
+  ),
 )
 
 const nearHardFlagRows = computed(() =>
   buildIssueTableRows(
     runResult.value?.nearHardFlags ?? [],
     enrichedRunRows.value,
+    lookups.value,
   ),
 )
 
@@ -643,9 +772,16 @@ async function loadLatestSavedSchedule(termValue: string) {
   }
 
   try {
-    savedSchedule.value = await $fetch<SavedScheduleDetails>(
-      `/api/schedule/${encodeURIComponent(termValue)}`,
+    const response = await $fetch<ScheduleTermRunsResponse>(
+      `/api/schedule/${encodeURIComponent(termValue)}/all`,
     )
+    const latestRunId = termEntry.runs[0]?._id
+    savedSchedule.value =
+      response.schedules.find(
+        (schedule: SavedScheduleDetails) => schedule._id === latestRunId,
+      ) ??
+      response.schedules[0] ??
+      null
   } catch {
     savedSchedule.value = null
   }
@@ -928,6 +1064,10 @@ onMounted(async () => {
   box-shadow: 0 22px 38px rgba(15, 23, 42, 0.08);
 }
 
+.schedule-admin-column-card {
+  min-width: 0;
+}
+
 .schedule-admin-hero__content {
   display: flex;
   align-items: flex-start;
@@ -1203,6 +1343,7 @@ onMounted(async () => {
 .schedule-saved-meta {
   display: grid;
   gap: 1rem;
+  min-width: 0;
 }
 
 .schedule-subsection h3 {
@@ -1217,6 +1358,45 @@ onMounted(async () => {
   padding: 1rem;
   text-align: center;
   color: var(--color-text-muted);
+}
+
+.schedule-table {
+  width: 100%;
+  min-width: 0;
+}
+
+.schedule-table :deep(.p-datatable-table-container) {
+  overflow: hidden;
+}
+
+.schedule-table :deep(.p-datatable-table) {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.schedule-table :deep(.p-datatable-thead > tr > th),
+.schedule-table :deep(.p-datatable-tbody > tr > td) {
+  padding: 0.45rem 0.55rem;
+  font-size: 0.74rem;
+  line-height: 1.25;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  vertical-align: top;
+}
+
+.schedule-table :deep(.p-datatable-tbody > tr > td) {
+  height: 4.15rem;
+}
+
+.schedule-table :deep(.p-column-header-content) {
+  align-items: flex-start;
+  gap: 0.3rem;
+}
+
+.schedule-table--issues :deep(.p-datatable-thead > tr > th),
+.schedule-table--issues :deep(.p-datatable-tbody > tr > td) {
+  font-size: 0.7rem;
 }
 
 @media (max-width: 1080px) {

--- a/app/pages/admin/schedule_viewer.vue
+++ b/app/pages/admin/schedule_viewer.vue
@@ -344,29 +344,53 @@
               <DataTable
                 :value="filteredRows"
                 stripedRows
-                scrollable
                 showGridlines
-                tableStyle="min-width: 88rem"
-                class="schedule-table"
+                class="schedule-table schedule-table--main"
               >
                 <template #empty>
                   <div class="schedule-table-empty">
                     No schedule rows match the current filters.
                   </div>
                 </template>
-                <Column field="department" header="Dept" sortable />
-                <Column field="courseNumber" header="Course" sortable />
-                <Column field="section" header="Section" sortable>
+                <Column field="department" header="Dept" sortable>
                   <template #body="{ data }">
-                    {{ data.section || 'N/A' }}
+                    <ScheduleCellPreview
+                      :value="data.department"
+                      title="Department"
+                    />
                   </template>
                 </Column>
-                <Column field="courseTitle" header="Title" sortable />
+                <Column field="courseNumber" header="Course" sortable>
+                  <template #body="{ data }">
+                    <ScheduleCellPreview
+                      :value="data.courseNumber"
+                      title="Course"
+                    />
+                  </template>
+                </Column>
+                <Column field="section" header="Section" sortable>
+                  <template #body="{ data }">
+                    <ScheduleCellPreview
+                      :value="data.section || 'N/A'"
+                      title="Section"
+                    />
+                  </template>
+                </Column>
+                <Column field="courseTitle" header="Title" sortable>
+                  <template #body="{ data }">
+                    <ScheduleCellPreview
+                      :value="data.courseTitle"
+                      title="Course Title"
+                    />
+                  </template>
+                </Column>
                 <Column field="instructorName" header="Instructor" sortable>
                   <template #body="{ data }">
-                    <span v-if="!isEditingRow(data.courseId)">{{
-                      data.instructorName
-                    }}</span>
+                    <ScheduleCellPreview
+                      v-if="!isEditingRow(data.courseId)"
+                      :value="data.instructorName"
+                      title="Instructor"
+                    />
                     <InputText
                       v-else
                       v-model="editDraft.professorId"
@@ -377,9 +401,11 @@
                 </Column>
                 <Column field="timeLabel" header="Time" sortable>
                   <template #body="{ data }">
-                    <div v-if="!isEditingRow(data.courseId)">
-                      {{ data.timeLabel }}
-                    </div>
+                    <ScheduleCellPreview
+                      v-if="!isEditingRow(data.courseId)"
+                      :value="data.timeLabel"
+                      title="Time"
+                    />
                     <div v-else class="schedule-edit-time">
                       <select
                         v-model="editDraft.days"
@@ -406,12 +432,21 @@
                     </div>
                   </template>
                 </Column>
-                <Column field="building" header="Building" sortable />
+                <Column field="building" header="Building" sortable>
+                  <template #body="{ data }">
+                    <ScheduleCellPreview
+                      :value="data.building"
+                      title="Building"
+                    />
+                  </template>
+                </Column>
                 <Column field="roomLabel" header="Room" sortable>
                   <template #body="{ data }">
-                    <span v-if="!isEditingRow(data.courseId)">{{
-                      data.roomLabel
-                    }}</span>
+                    <ScheduleCellPreview
+                      v-if="!isEditingRow(data.courseId)"
+                      :value="data.roomLabel"
+                      title="Room"
+                    />
                     <InputText
                       v-else
                       v-model="editDraft.roomId"
@@ -422,12 +457,18 @@
                 </Column>
                 <Column field="enrollment" header="Enroll" sortable>
                   <template #body="{ data }">
-                    {{ data.enrollment ?? 'N/A' }}
+                    <ScheduleCellPreview
+                      :value="data.enrollment ?? 'N/A'"
+                      title="Enrollment"
+                    />
                   </template>
                 </Column>
                 <Column field="overrideBy" header="Override By" sortable>
                   <template #body="{ data }">
-                    {{ data.overrideBy || 'N/A' }}
+                    <ScheduleCellPreview
+                      :value="data.overrideBy || 'N/A'"
+                      title="Override By"
+                    />
                   </template>
                 </Column>
                 <Column header="Actions">
@@ -486,21 +527,56 @@
                 <DataTable
                   :value="selectedConflictRows"
                   stripedRows
-                  scrollable
                   showGridlines
-                  tableStyle="min-width: 65rem"
+                  class="schedule-table schedule-table--issues"
                 >
                   <template #empty>
                     <div class="schedule-table-empty">
                       No conflicts saved for this run.
                     </div>
                   </template>
-                  <Column field="courseId" header="Course" sortable />
-                  <Column field="instructor" header="Instructor" sortable />
-                  <Column field="room" header="Room" sortable />
-                  <Column field="time" header="Time" sortable />
-                  <Column field="issueType" header="Issue Type" sortable />
-                  <Column field="reason" header="Reason" />
+                  <Column field="courseLabel" header="Course" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.courseLabel"
+                        title="Course"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="instructor" header="Instructor" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.instructor"
+                        title="Instructor"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="room" header="Room" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview :value="data.room" title="Room" />
+                    </template>
+                  </Column>
+                  <Column field="time" header="Time" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview :value="data.time" title="Time" />
+                    </template>
+                  </Column>
+                  <Column field="issueType" header="Issue Type" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.issueType"
+                        title="Issue Type"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="reason" header="Reason">
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.reason"
+                        title="Reason"
+                      />
+                    </template>
+                  </Column>
                 </DataTable>
               </div>
 
@@ -509,58 +585,132 @@
                 <DataTable
                   :value="selectedNearHardFlagRows"
                   stripedRows
-                  scrollable
                   showGridlines
-                  tableStyle="min-width: 65rem"
+                  class="schedule-table schedule-table--issues"
                 >
                   <template #empty>
                     <div class="schedule-table-empty">
                       No near-hard flags were saved for this run.
                     </div>
                   </template>
-                  <Column field="courseId" header="Course" sortable />
-                  <Column field="instructor" header="Instructor" sortable />
-                  <Column field="room" header="Room" sortable />
-                  <Column field="time" header="Time" sortable />
-                  <Column field="issueType" header="Issue Type" sortable />
-                  <Column field="reason" header="Reason" />
+                  <Column field="courseLabel" header="Course" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.courseLabel"
+                        title="Course"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="instructor" header="Instructor" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.instructor"
+                        title="Instructor"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="room" header="Room" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview :value="data.room" title="Room" />
+                    </template>
+                  </Column>
+                  <Column field="time" header="Time" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview :value="data.time" title="Time" />
+                    </template>
+                  </Column>
+                  <Column field="issueType" header="Issue Type" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.issueType"
+                        title="Issue Type"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="reason" header="Reason">
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.reason"
+                        title="Reason"
+                      />
+                    </template>
+                  </Column>
                 </DataTable>
               </div>
 
               <div class="schedule-subsection">
                 <h3>Trace Output</h3>
+                <p class="schedule-trace-note">
+                  Condensed placement trace for review. Open the saved export if
+                  you need the full raw trace payload.
+                </p>
                 <DataTable
                   :value="selectedTraceRows"
                   stripedRows
-                  scrollable
                   showGridlines
-                  tableStyle="min-width: 95rem"
+                  class="schedule-table schedule-table--trace"
                 >
                   <template #empty>
                     <div class="schedule-table-empty">
                       No placement traces were saved for this run.
                     </div>
                   </template>
-                  <Column field="courseId" header="Course" sortable />
-                  <Column
-                    field="catalogCourseId"
-                    header="Catalog Course"
-                    sortable
-                  />
-                  <Column field="professorId" header="Professor Id" sortable />
-                  <Column field="status" header="Status" sortable />
-                  <Column field="stageLabel" header="Stage" sortable />
-                  <Column field="candidateCount" header="Candidates" sortable />
-                  <Column field="chosenPlacement" header="Chosen Placement" />
-                  <Column
-                    field="candidateRoomsLabel"
-                    header="Candidate Rooms"
-                  />
-                  <Column
-                    field="candidateSlotsLabel"
-                    header="Candidate Slots"
-                  />
-                  <Column field="reasonsLabel" header="Reasons" />
+                  <Column field="courseLabel" header="Course" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.courseLabel"
+                        title="Course"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="professorName" header="Professor" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.professorName"
+                        title="Professor"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="outcomeLabel" header="Outcome" sortable>
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.outcomeLabel"
+                        title="Outcome"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="chosenPlacement" header="Placement">
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.chosenPlacement"
+                        title="Placement"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="candidateSummary" header="Candidates">
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.candidateSummary"
+                        title="Candidates"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="candidatePreview" header="Preview">
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.candidatePreview"
+                        title="Candidate Preview"
+                      />
+                    </template>
+                  </Column>
+                  <Column field="notesSummary" header="Notes">
+                    <template #body="{ data }">
+                      <ScheduleCellPreview
+                        :value="data.notesSummary"
+                        title="Notes"
+                      />
+                    </template>
+                  </Column>
                 </DataTable>
               </div>
             </div>
@@ -575,6 +725,7 @@
 import {
   buildEnrichedScheduleRows,
   buildIssueTableRows,
+  buildTraceTableRows,
 } from '~~/app/utils/schedule'
 import {
   downloadScheduleExport,
@@ -701,6 +852,7 @@ const selectedConflictRows = computed(() =>
   buildIssueTableRows(
     selectedSchedule.value?.conflicts ?? [],
     enrichedRows.value,
+    lookups.value,
   ),
 )
 
@@ -708,6 +860,7 @@ const selectedNearHardFlagRows = computed(() =>
   buildIssueTableRows(
     selectedSchedule.value?.nearHardFlags ?? [],
     enrichedRows.value,
+    lookups.value,
   ),
 )
 
@@ -723,25 +876,7 @@ const selectedRecommendedStatus = computed<ScheduleStatus>(() => {
 })
 
 const selectedTraceRows = computed(() =>
-  (selectedSchedule.value?.traces ?? []).map((trace) => ({
-    courseId: trace.courseId,
-    catalogCourseId: trace.catalogCourseId,
-    professorId: trace.professorId,
-    status: trace.status,
-    stageLabel: trace.stage
-      .replace(/_/g, ' ')
-      .replace(/\b\w/g, (character) => character.toUpperCase()),
-    candidateCount: trace.candidateCount,
-    chosenPlacement: trace.chosen
-      ? `${trace.chosen.days} ${trace.chosen.startTime}-${trace.chosen.endTime} @ ${trace.chosen.roomId}`
-      : 'None',
-    candidateRoomsLabel: trace.candidateRooms.join(', ') || 'None',
-    candidateSlotsLabel:
-      trace.candidateSlots
-        .map((slot) => `${slot.days} ${slot.startTime}-${slot.endTime}`)
-        .join(', ') || 'None',
-    reasonsLabel: trace.reasons.join('; ') || 'None',
-  })),
+  buildTraceTableRows(selectedSchedule.value?.traces ?? [], lookups.value),
 )
 
 const selectedScheduleTitle = computed(() => {
@@ -866,11 +1001,7 @@ function findScheduleFromQuery() {
     )
   }
 
-  return (
-    matchingSchedules.find((schedule) => (schedule.assignmentCount ?? 0) > 0) ??
-    matchingSchedules[0] ??
-    null
-  )
+  return matchingSchedules[0] ?? null
 }
 
 function resetFilters() {
@@ -1084,12 +1215,7 @@ async function exportSelectedSchedule(format: ScheduleExportFormat) {
 onMounted(async () => {
   await loadSchedules()
   const initialSchedule =
-    findScheduleFromQuery() ??
-    scheduleItems.value.find(
-      (schedule) => (schedule.assignmentCount ?? 0) > 0,
-    ) ??
-    scheduleItems.value[0] ??
-    null
+    findScheduleFromQuery() ?? scheduleItems.value[0] ?? null
   if (!initialSchedule) {
     selectedTerm.value =
       normalizeQueryValue(route.query.term).trim() || termKeys.value[0] || ''
@@ -1131,6 +1257,7 @@ onMounted(async () => {
 .schedule-history-main,
 .schedule-history-main-card {
   height: 100%;
+  min-width: 0;
 }
 
 .schedule-history-sidebar :deep(.p-card),
@@ -1243,6 +1370,7 @@ onMounted(async () => {
 .schedule-subsection {
   display: grid;
   gap: 1rem;
+  min-width: 0;
 }
 
 .schedule-meta-grid,
@@ -1260,8 +1388,10 @@ onMounted(async () => {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 0.75rem;
   grid-column: 1 / -1;
+  min-width: 0;
 }
 
 .schedule-filter-grid__count {
@@ -1289,6 +1419,7 @@ onMounted(async () => {
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem;
+  min-width: 0;
 }
 
 .schedule-filter-grid label {
@@ -1342,6 +1473,58 @@ onMounted(async () => {
   margin-top: 0.9rem;
 }
 
+.schedule-table {
+  width: 100%;
+  min-width: 0;
+}
+
+.schedule-table :deep(.p-datatable-table-container) {
+  overflow: hidden;
+}
+
+.schedule-table :deep(.p-datatable-table) {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.schedule-table :deep(.p-datatable-thead > tr > th),
+.schedule-table :deep(.p-datatable-tbody > tr > td) {
+  padding: 0.45rem 0.55rem;
+  font-size: 0.74rem;
+  line-height: 1.25;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  vertical-align: top;
+}
+
+.schedule-table :deep(.p-datatable-tbody > tr > td) {
+  height: 4.15rem;
+}
+
+.schedule-table :deep(.p-column-header-content) {
+  align-items: flex-start;
+  gap: 0.3rem;
+}
+
+.schedule-table :deep(.p-button) {
+  padding: 0.35rem 0.55rem;
+  font-size: 0.72rem;
+}
+
+.schedule-table :deep(.p-inputtext) {
+  min-width: 0;
+  font-size: 0.74rem;
+  padding: 0.45rem 0.55rem;
+}
+
+.schedule-table--trace :deep(.p-datatable-thead > tr > th),
+.schedule-table--trace :deep(.p-datatable-tbody > tr > td),
+.schedule-table--issues :deep(.p-datatable-thead > tr > th),
+.schedule-table--issues :deep(.p-datatable-tbody > tr > td) {
+  font-size: 0.7rem;
+}
+
 .schedule-table-empty {
   padding: 1rem;
   text-align: center;
@@ -1350,6 +1533,12 @@ onMounted(async () => {
 
 .schedule-subsection h3 {
   margin: 0;
+}
+
+.schedule-trace-note {
+  margin: -0.35rem 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.82rem;
 }
 
 @media (max-width: 1120px) {

--- a/app/pages/admin/schedule_viewer.vue
+++ b/app/pages/admin/schedule_viewer.vue
@@ -1473,64 +1473,6 @@ onMounted(async () => {
   margin-top: 0.9rem;
 }
 
-.schedule-table {
-  width: 100%;
-  min-width: 0;
-}
-
-.schedule-table :deep(.p-datatable-table-container) {
-  overflow: hidden;
-}
-
-.schedule-table :deep(.p-datatable-table) {
-  width: 100%;
-  table-layout: fixed;
-}
-
-.schedule-table :deep(.p-datatable-thead > tr > th),
-.schedule-table :deep(.p-datatable-tbody > tr > td) {
-  padding: 0.45rem 0.55rem;
-  font-size: 0.74rem;
-  line-height: 1.25;
-  white-space: normal;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-  vertical-align: top;
-}
-
-.schedule-table :deep(.p-datatable-tbody > tr > td) {
-  height: 4.15rem;
-}
-
-.schedule-table :deep(.p-column-header-content) {
-  align-items: flex-start;
-  gap: 0.3rem;
-}
-
-.schedule-table :deep(.p-button) {
-  padding: 0.35rem 0.55rem;
-  font-size: 0.72rem;
-}
-
-.schedule-table :deep(.p-inputtext) {
-  min-width: 0;
-  font-size: 0.74rem;
-  padding: 0.45rem 0.55rem;
-}
-
-.schedule-table--trace :deep(.p-datatable-thead > tr > th),
-.schedule-table--trace :deep(.p-datatable-tbody > tr > td),
-.schedule-table--issues :deep(.p-datatable-thead > tr > th),
-.schedule-table--issues :deep(.p-datatable-tbody > tr > td) {
-  font-size: 0.7rem;
-}
-
-.schedule-table-empty {
-  padding: 1rem;
-  text-align: center;
-  color: var(--color-text-muted);
-}
-
 .schedule-subsection h3 {
   margin: 0;
 }

--- a/app/pages/faculty/preferences.vue
+++ b/app/pages/faculty/preferences.vue
@@ -213,7 +213,7 @@
             </Column>
 
             <!-- Course Name -->
-            <Column header="Course Name" style="width: 15rem">
+            <Column header="Course Name" style="width: 13rem">
               <template #body="{ data }">
                 <AutoComplete
                   v-model="data.courseName"
@@ -319,13 +319,19 @@
                     @update:modelValue="clearRowError(data)"
                     @blur="handleTimeChange(data)"
                   />
-                  <SelectButton
-                    :modelValue="timePeriodForRow(data)"
-                    :options="timePeriodOptions"
-                    :allowEmpty="false"
-                    class="pref-time-period"
-                    @update:modelValue="setTimePeriod(data, $event)"
-                  />
+                  <select
+                    :value="timePeriodForRow(data)"
+                    class="pref-time-period-select"
+                    @change="handleTimePeriodChange(data, $event)"
+                  >
+                    <option
+                      v-for="option in timePeriodOptions"
+                      :key="option"
+                      :value="option"
+                    >
+                      {{ option }}
+                    </option>
+                  </select>
                 </div>
               </template>
             </Column>
@@ -423,7 +429,7 @@
             </Column>
 
             <!-- Row Actions -->
-            <Column header="Actions" style="width: 12rem">
+            <Column header="Actions" style="width: 10rem">
               <template #body="{ data }">
                 <div class="pref-row-actions">
                   <div class="pref-row-actions__buttons">
@@ -1000,6 +1006,11 @@ function timePeriodForRow(row: PreferenceRow): 'AM' | 'PM' {
   if (!TIME_PATTERN.test(nt)) return 'AM'
   const [h] = nt.split(':')
   return Number(h) >= 12 ? 'PM' : 'AM'
+}
+
+function handleTimePeriodChange(row: PreferenceRow, event: Event) {
+  const nextValue = (event.target as HTMLSelectElement | null)?.value
+  setTimePeriod(row, nextValue === 'PM' ? 'PM' : 'AM')
 }
 
 function setTimePeriod(row: PreferenceRow, period: 'AM' | 'PM') {
@@ -2259,6 +2270,13 @@ onMounted(loadPageData)
     box-shadow 0.15s;
 }
 
+:deep(.pref-cell-input::placeholder),
+:deep(.pref-autocomplete-input::placeholder),
+:deep(.pref-page .p-inputtext::placeholder) {
+  color: var(--color-example-text, #c8cace) !important;
+  opacity: 1 !important;
+}
+
 :deep(.pref-cell-input:hover) {
   border-color: var(--p-primary-300, #93c5fd) !important;
 }
@@ -2291,17 +2309,21 @@ onMounted(loadPageData)
   align-items: center;
 }
 
-.pref-time-period {
-  min-width: 5.1rem;
-}
-
-:deep(.pref-time-period .p-button) {
-  padding: 0.35rem 0.45rem;
-}
-
-:deep(.pref-page .p-inputtext::placeholder) {
+.pref-time-period-select {
+  min-width: 4.2rem;
+  height: 2rem;
+  padding: 0.35rem 1.55rem 0.35rem 0.45rem;
+  border-radius: 6px;
+  border: 1px solid var(--p-surface-300, #cbd5e1);
+  background: var(--p-surface-0, #ffffff);
   color: inherit;
-  opacity: 0.7;
+  font-size: 0.76rem;
+}
+
+.pref-time-period-select:focus-visible {
+  border-color: var(--p-primary-400, #60a5fa);
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.18);
+  outline: none;
 }
 
 :deep(.pref-page .p-button.p-button-outlined) {
@@ -2334,7 +2356,7 @@ onMounted(loadPageData)
 
 .pref-row-hint {
   font-size: 0.69rem;
-  color: var(--p-text-muted-color, #94a3b8);
+  color: var(--color-example-text, #c8cace);
   line-height: 1.35;
 }
 

--- a/app/utils/schedule.ts
+++ b/app/utils/schedule.ts
@@ -1,6 +1,7 @@
 import type {
   CourseRecord,
   EnrichedScheduleRow,
+  PlacementTrace,
   PreferenceSubmissionRecord,
   ProfessorRecord,
   RoomRecord,
@@ -14,6 +15,51 @@ function normalizeWhitespace(value: string): string {
 
 function looksLikeOpaqueId(value: string): boolean {
   return /^[a-f0-9]{24}$/i.test(value)
+}
+
+function looksLikeOpaqueReference(value: string): boolean {
+  return /^([a-f0-9]{24})(-[a-z0-9]+)?$/i.test(value)
+}
+
+function normalizeLookupKey(value: string): string {
+  const normalized = normalizeWhitespace(value)
+  return looksLikeOpaqueReference(normalized)
+    ? normalized.toLowerCase()
+    : normalized
+}
+
+function setLookupAlias<Value>(
+  map: Map<string, Value>,
+  key: string | null | undefined,
+  value: Value,
+) {
+  if (!key) return
+
+  const normalized = normalizeWhitespace(String(key))
+  if (!normalized) return
+
+  map.set(normalized, value)
+  map.set(normalized.toLowerCase(), value)
+  map.set(normalized.toUpperCase(), value)
+
+  if (looksLikeOpaqueId(normalized)) {
+    map.set(normalized.toLowerCase(), value)
+  }
+}
+
+function getLookupValue<Value>(
+  map: Map<string, Value>,
+  key: string,
+): Value | undefined {
+  const normalized = normalizeWhitespace(key)
+  if (!normalized) return undefined
+
+  return (
+    map.get(normalized) ??
+    map.get(normalized.toLowerCase()) ??
+    map.get(normalized.toUpperCase()) ??
+    map.get(normalizeLookupKey(normalized))
+  )
 }
 
 function normalizeCourseIdText(value: string): string {
@@ -34,6 +80,16 @@ function parseEmbeddedSection(normalizedCourseId: string): {
   catalogCourseId: string
   section: string | null
 } {
+  const opaqueMatch = normalizedCourseId.match(/^([a-f0-9]{24})-([A-Z0-9]+)$/i)
+  if (opaqueMatch) {
+    return {
+      catalogCourseId: normalizeCourseIdText(
+        opaqueMatch[1] ?? normalizedCourseId,
+      ),
+      section: normalizeSectionText(opaqueMatch[2] ?? null),
+    }
+  }
+
   const match = normalizedCourseId.match(/^(.+\s+\S+)-([A-Z0-9]+)$/)
   if (!match) {
     return {
@@ -111,22 +167,30 @@ export function buildScheduleLookupData(input: {
   rooms: RoomRecord[]
   preferences: PreferenceSubmissionRecord[]
 }) {
-  const coursesById = new Map(
-    input.courses.map((course) => [course._id, course]),
-  )
+  const coursesById = new Map<string, CourseRecord>()
   const professorsById = new Map<string, ProfessorRecord>()
   const roomsById = new Map<string, RoomRecord>()
   const enrollmentByKey = new Map<string, number>()
 
+  function buildEnrollmentKey(professorKey: string, courseKey: string) {
+    return `${normalizeLookupKey(professorKey)}::${normalizeLookupKey(courseKey)}`
+  }
+
+  for (const course of input.courses) {
+    setLookupAlias(coursesById, course._id, course)
+  }
+
   for (const professor of input.professors) {
-    professorsById.set(professor._id, professor)
-    professorsById.set(professor.covenantId, professor)
-    professorsById.set(professor.covenantId.toLowerCase(), professor)
+    setLookupAlias(professorsById, professor._id, professor)
+    setLookupAlias(professorsById, professor.covenantId, professor)
+    setLookupAlias(professorsById, professor.displayName, professor)
   }
 
   for (const room of input.rooms) {
-    roomsById.set(room._id, room)
-    roomsById.set(room.abbreviation, room)
+    setLookupAlias(roomsById, room._id, room)
+    setLookupAlias(roomsById, room.abbreviation, room)
+    setLookupAlias(roomsById, room.displayName, room)
+    setLookupAlias(roomsById, `${room.buildingName} ${room.roomNumber}`, room)
   }
 
   for (const submission of input.preferences) {
@@ -141,11 +205,11 @@ export function buildScheduleLookupData(input: {
         submission.covenantId.toLowerCase(),
       ]) {
         enrollmentByKey.set(
-          `${professorKey}::${normalized.scheduledCourseId}`,
+          buildEnrollmentKey(professorKey, normalized.scheduledCourseId),
           course.expectedEnrollment,
         )
         enrollmentByKey.set(
-          `${professorKey}::${normalized.catalogCourseId}`,
+          buildEnrollmentKey(professorKey, normalized.catalogCourseId),
           course.expectedEnrollment,
         )
       }
@@ -158,6 +222,140 @@ export function buildScheduleLookupData(input: {
     roomsById,
     enrollmentByKey,
   }
+}
+
+function lookupCourse(
+  lookups: ReturnType<typeof buildScheduleLookupData>,
+  courseId: string,
+  section?: string | null,
+) {
+  const normalized = normalizeCourseReference(courseId, section)
+
+  return {
+    normalized,
+    course:
+      getLookupValue(lookups.coursesById, normalized.catalogCourseId) ??
+      getLookupValue(lookups.coursesById, normalized.rawCourseId),
+  }
+}
+
+function lookupProfessor(
+  lookups: ReturnType<typeof buildScheduleLookupData>,
+  professorId: string,
+) {
+  return getLookupValue(lookups.professorsById, professorId)
+}
+
+function lookupRoom(
+  lookups: ReturnType<typeof buildScheduleLookupData>,
+  roomId: string,
+) {
+  return getLookupValue(lookups.roomsById, roomId)
+}
+
+function resolveReferenceLabel(
+  lookups: ReturnType<typeof buildScheduleLookupData>,
+  value: string,
+): string | null {
+  const professor = lookupProfessor(lookups, value)
+  if (professor) {
+    return professor.displayName
+  }
+
+  const room = lookupRoom(lookups, value)
+  if (room) {
+    return roomLabel(room, value)
+  }
+
+  const { normalized, course } = lookupCourse(lookups, value)
+  if (course || normalized.catalogCourseId !== value) {
+    return formatCourseLabel({
+      catalogCourseId: normalized.catalogCourseId,
+      course,
+      section: normalized.section,
+      fallbackCourseId: value,
+    })
+  }
+
+  return null
+}
+
+function replaceOpaqueReferences(
+  text: string,
+  lookups?: ReturnType<typeof buildScheduleLookupData>,
+) {
+  if (!lookups) return text
+
+  return text.replace(
+    /\b[a-f0-9]{24}(?:-[a-z0-9]+)?\b/gi,
+    (match) => resolveReferenceLabel(lookups, match) ?? match,
+  )
+}
+
+function summarizeList(items: string[], maxVisible = 2): string {
+  if (items.length === 0) return 'None'
+
+  const visible = items.slice(0, maxVisible)
+  const remaining = items.length - visible.length
+  return remaining > 0
+    ? `${visible.join(', ')} +${remaining} more`
+    : visible.join(', ')
+}
+
+function compactTraceReason(
+  reason: string,
+  lookups: ReturnType<typeof buildScheduleLookupData>,
+) {
+  const withNames = replaceOpaqueReferences(reason, lookups)
+  const withoutManualOptions = withNames.replace(
+    /\s*Manual options:\s*.+$/i,
+    '',
+  )
+  const withoutAttemptSummary = withoutManualOptions.replace(
+    /\s*Placement attempts exhausted:[^.]+\./i,
+    '',
+  )
+  return withoutAttemptSummary.trim().replace(/\s+/g, ' ')
+}
+
+function lookupEnrollment(
+  lookups: ReturnType<typeof buildScheduleLookupData>,
+  professorId: string,
+  normalizedCourseId: {
+    scheduledCourseId: string
+    catalogCourseId: string
+  },
+) {
+  for (const key of [
+    `${normalizeLookupKey(professorId)}::${normalizeLookupKey(normalizedCourseId.scheduledCourseId)}`,
+    `${normalizeLookupKey(professorId)}::${normalizeLookupKey(normalizedCourseId.catalogCourseId)}`,
+  ]) {
+    const match = lookups.enrollmentByKey.get(key)
+    if (match !== undefined) {
+      return match
+    }
+  }
+
+  return null
+}
+
+function formatCourseLabel(input: {
+  catalogCourseId: string
+  course?: CourseRecord
+  section?: string | null
+  fallbackCourseId?: string
+}) {
+  const baseLabel = input.course
+    ? [input.course.deptCode, input.course.courseNumber]
+        .filter(Boolean)
+        .join(' ')
+    : input.catalogCourseId
+
+  if (!baseLabel) {
+    return input.fallbackCourseId ?? 'Unassigned'
+  }
+
+  return input.section ? `${baseLabel}-${input.section}` : baseLabel
 }
 
 function roomBuilding(room: RoomRecord | undefined): string {
@@ -179,28 +377,14 @@ export function buildEnrichedScheduleRows(
   lookups: ReturnType<typeof buildScheduleLookupData>,
 ): EnrichedScheduleRow[] {
   return assignments.map((assignment) => {
-    const normalized = normalizeCourseReference(assignment.courseId)
-    const course = lookups.coursesById.get(normalized.catalogCourseId)
-    const professor =
-      lookups.professorsById.get(assignment.professorId) ??
-      lookups.professorsById.get(assignment.professorId.toLowerCase())
-    const room =
-      lookups.roomsById.get(assignment.roomId) ??
-      lookups.roomsById.get(assignment.roomId.toUpperCase())
-    const enrollment =
-      lookups.enrollmentByKey.get(
-        `${assignment.professorId}::${normalized.scheduledCourseId}`,
-      ) ??
-      lookups.enrollmentByKey.get(
-        `${assignment.professorId.toLowerCase()}::${normalized.scheduledCourseId}`,
-      ) ??
-      lookups.enrollmentByKey.get(
-        `${assignment.professorId}::${normalized.catalogCourseId}`,
-      ) ??
-      lookups.enrollmentByKey.get(
-        `${assignment.professorId.toLowerCase()}::${normalized.catalogCourseId}`,
-      ) ??
-      null
+    const { normalized, course } = lookupCourse(lookups, assignment.courseId)
+    const professor = lookupProfessor(lookups, assignment.professorId)
+    const room = lookupRoom(lookups, assignment.roomId)
+    const enrollment = lookupEnrollment(
+      lookups,
+      assignment.professorId,
+      normalized,
+    )
 
     return {
       courseId: assignment.courseId,
@@ -231,8 +415,10 @@ export function buildEnrichedScheduleRows(
 export function buildIssueTableRows(
   issues: ScheduleIssue[],
   rows: EnrichedScheduleRow[],
+  lookups?: ReturnType<typeof buildScheduleLookupData>,
 ): Array<{
   courseId: string
+  courseLabel: string
   courseTitle: string
   instructor: string
   room: string
@@ -240,18 +426,113 @@ export function buildIssueTableRows(
   issueType: string
   reason: string
 }> {
-  const rowsByCourseId = new Map(rows.map((row) => [row.courseId, row]))
+  const rowsByCourseId = new Map<string, EnrichedScheduleRow>()
+
+  for (const row of rows) {
+    rowsByCourseId.set(row.courseId, row)
+    rowsByCourseId.set(normalizeLookupKey(row.courseId), row)
+    rowsByCourseId.set(normalizeLookupKey(row.catalogCourseId), row)
+  }
 
   return issues.map((issue) => {
-    const row = rowsByCourseId.get(issue.courseId)
+    const row =
+      rowsByCourseId.get(issue.courseId) ??
+      rowsByCourseId.get(normalizeLookupKey(issue.courseId))
+
     return {
       courseId: issue.courseId,
+      courseLabel: row
+        ? formatCourseLabel({
+            catalogCourseId: row.catalogCourseId,
+            section: row.section,
+            fallbackCourseId: row.courseId,
+            course: {
+              _id: row.catalogCourseId,
+              deptCode: row.department,
+              courseNumber: row.courseNumber,
+              title: row.courseTitle,
+              creditHours: 0,
+            },
+          })
+        : issue.courseId,
       courseTitle: row?.courseTitle ?? issue.courseId,
       instructor: row?.instructorName ?? 'Unassigned',
       room: row?.roomLabel ?? 'Unassigned',
       time: row?.timeLabel ?? 'Unassigned',
       issueType: issueTypeFromReason(issue.reason),
-      reason: issue.reason,
+      reason: replaceOpaqueReferences(issue.reason, lookups),
+    }
+  })
+}
+
+export function buildTraceTableRows(
+  traces: PlacementTrace[],
+  lookups: ReturnType<typeof buildScheduleLookupData>,
+) {
+  return traces.map((trace) => {
+    const { normalized, course } = lookupCourse(
+      lookups,
+      trace.courseId,
+      trace.courseId === trace.catalogCourseId ? null : undefined,
+    )
+    const normalizedCatalog = normalizeCourseReference(trace.catalogCourseId)
+    const catalogCourse =
+      lookupCourse(lookups, trace.catalogCourseId, normalizedCatalog.section)
+        .course ?? course
+    const professor = lookupProfessor(lookups, trace.professorId)
+    const chosenRoom = trace.chosen?.roomId
+      ? lookupRoom(lookups, trace.chosen.roomId)
+      : undefined
+
+    const candidateRoomLabels = trace.candidateRooms.map((candidateRoomId) =>
+      roomLabel(lookupRoom(lookups, candidateRoomId), candidateRoomId),
+    )
+    const candidateSlotLabels = trace.candidateSlots.map(
+      (slot) => `${slot.days} ${slot.startTime}-${slot.endTime}`,
+    )
+    const compactReasons = trace.reasons
+      .map((reason) => compactTraceReason(reason, lookups))
+      .filter(Boolean)
+
+    return {
+      courseId: trace.courseId,
+      courseLabel: formatCourseLabel({
+        catalogCourseId: normalized.catalogCourseId,
+        course,
+        section: normalized.section,
+        fallbackCourseId: trace.courseId,
+      }),
+      catalogCourseId: trace.catalogCourseId,
+      catalogCourseLabel: formatCourseLabel({
+        catalogCourseId: normalizedCatalog.catalogCourseId,
+        course: catalogCourse,
+        section: normalizedCatalog.section,
+        fallbackCourseId: trace.catalogCourseId,
+      }),
+      courseTitle:
+        course?.title ?? catalogCourse?.title ?? normalized.catalogCourseId,
+      professorId: trace.professorId,
+      professorName: professor?.displayName ?? trace.professorId,
+      status: trace.status,
+      outcomeLabel: `${trace.status === 'assigned' ? 'Assigned' : 'Conflict'} / ${trace.stage
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, (character) => character.toUpperCase())}`,
+      stageLabel: trace.stage
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, (character) => character.toUpperCase()),
+      candidateCount: trace.candidateCount,
+      chosenPlacement: trace.chosen
+        ? `${trace.chosen.days} ${trace.chosen.startTime}-${trace.chosen.endTime} @ ${roomLabel(chosenRoom, trace.chosen.roomId)}`
+        : 'None',
+      candidateRoomsLabel: candidateRoomLabels.join(', ') || 'None',
+      candidateSlotsLabel: candidateSlotLabels.join(', ') || 'None',
+      candidateSummary:
+        trace.candidateCount > 0
+          ? `${trace.candidateCount} pairings from ${candidateRoomLabels.length} room(s) and ${candidateSlotLabels.length} slot(s)`
+          : `${candidateRoomLabels.length} room(s), ${candidateSlotLabels.length} slot(s), no surviving pairings`,
+      candidatePreview: `Rooms: ${summarizeList(candidateRoomLabels)} | Slots: ${summarizeList(candidateSlotLabels)}`,
+      reasonsLabel: compactReasons.join('; ') || 'None',
+      notesSummary: summarizeList(compactReasons, 1),
     }
   })
 }

--- a/server/api/schedule/index.get.ts
+++ b/server/api/schedule/index.get.ts
@@ -6,12 +6,13 @@ import { defineEventHandler } from 'h3'
 import { requireAuth } from '../../utils/auth'
 import { connectDB } from '../../utils/db'
 import { Schedule } from '../../models/index'
+import { compareAcademicTermsDesc } from '../../../shared/academicTerms'
 
 export default defineEventHandler(async (event) => {
   requireAuth(event, ['Admin', 'Faculty'])
   await connectDB()
 
-  return Schedule.find(
+  const schedules = await Schedule.find(
     {},
     {
       _id: 1,
@@ -25,7 +26,12 @@ export default defineEventHandler(async (event) => {
       approvedBy: 1,
     },
   )
-    .sort({ term: -1, runNumber: -1 })
     .lean()
     .exec()
+
+  return schedules.sort(
+    (left, right) =>
+      compareAcademicTermsDesc(left.term, right.term) ||
+      right.runNumber - left.runNumber,
+  )
 })

--- a/server/api/schedule/terms.get.ts
+++ b/server/api/schedule/terms.get.ts
@@ -6,6 +6,7 @@ import { defineEventHandler } from 'h3'
 import { requireAuth } from '../../utils/auth'
 import { connectDB } from '../../utils/db'
 import { Professor, Schedule, type ScheduleStatus } from '../../models/index'
+import { compareAcademicTermsDesc } from '../../../shared/academicTerms'
 
 type ScheduleSummaryAggregate = {
   _id: string
@@ -100,7 +101,13 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  return [...entriesByTerm.values()].sort((left, right) =>
-    right.term.localeCompare(left.term),
+  const entries = [...entriesByTerm.values()]
+
+  for (const entry of entries) {
+    entry.runs.sort((left, right) => right.runNumber - left.runNumber)
+  }
+
+  return entries.sort((left, right) =>
+    compareAcademicTermsDesc(left.term, right.term),
   )
 })

--- a/server/services/scheduling/scheduleExport.ts
+++ b/server/services/scheduling/scheduleExport.ts
@@ -38,6 +38,58 @@ const bannerHeaders = [
 
 type BannerRow = Record<(typeof bannerHeaders)[number], string | number>
 
+function normalizeWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, ' ')
+}
+
+function looksLikeOpaqueReference(value: string): boolean {
+  return /^([a-f0-9]{24})(-[a-z0-9]+)?$/i.test(value)
+}
+
+function normalizeLookupKey(value: string): string {
+  const normalized = normalizeWhitespace(value)
+  return looksLikeOpaqueReference(normalized)
+    ? normalized.toLowerCase()
+    : normalized
+}
+
+function setLookupAlias<Value>(
+  map: Map<string, Value>,
+  key: string | null | undefined,
+  value: Value,
+) {
+  if (!key) return
+
+  const normalized = normalizeWhitespace(String(key))
+  if (!normalized) return
+
+  map.set(normalized, value)
+  map.set(normalized.toLowerCase(), value)
+  map.set(normalized.toUpperCase(), value)
+  map.set(normalizeLookupKey(normalized), value)
+}
+
+function getLookupValue<Value>(
+  map: Map<string, Value>,
+  key: string | null | undefined,
+): Value | undefined {
+  if (!key) return undefined
+
+  const normalized = normalizeWhitespace(String(key))
+  if (!normalized) return undefined
+
+  return (
+    map.get(normalized) ??
+    map.get(normalized.toLowerCase()) ??
+    map.get(normalized.toUpperCase()) ??
+    map.get(normalizeLookupKey(normalized))
+  )
+}
+
+function buildEnrollmentKey(professorKey: string, courseKey: string) {
+  return `${normalizeLookupKey(professorKey)}::${normalizeLookupKey(courseKey)}`
+}
+
 async function loadXlsxModule() {
   const module = await import('xlsx')
   return module.default ?? module
@@ -55,6 +107,63 @@ function getBuildingCode(roomAbbreviation: string): string {
   return roomAbbreviation.split(/\s+/)[0] ?? ''
 }
 
+function looksLikeOpaqueId(value: string): boolean {
+  return /^[a-f0-9]{24}$/i.test(value)
+}
+
+function formatExportCourseLabel(input: {
+  assignment: IAssignment
+  course?: {
+    deptCode: string
+    courseNumber: string
+    title: string
+    creditHours: number
+  }
+}) {
+  const section = courseSectionOf(input.assignment.courseId)
+  const base = input.course
+    ? [input.course.deptCode, input.course.courseNumber]
+        .filter(Boolean)
+        .join(' ')
+    : null
+
+  if (base) {
+    return section ? `${base}-${section}` : base
+  }
+
+  return section ? `Unresolved course (${section})` : 'Unresolved course'
+}
+
+function formatExportProfessorLabel(professor?: {
+  covenantId: string
+  displayName?: string
+}) {
+  if (professor?.displayName) {
+    return professor.displayName
+  }
+
+  if (professor?.covenantId && !looksLikeOpaqueId(professor.covenantId)) {
+    return professor.covenantId
+  }
+
+  return 'Unresolved professor'
+}
+
+function formatExportRoomLabel(room?: {
+  abbreviation: string
+  roomNumber: string
+}) {
+  if (room?.abbreviation) {
+    return room.abbreviation
+  }
+
+  if (room?.roomNumber) {
+    return `Room ${room.roomNumber}`
+  }
+
+  return 'Unresolved room'
+}
+
 function buildBannerRowData(
   term: string,
   assignments: IAssignment[],
@@ -68,7 +177,7 @@ function buildBannerRowData(
         creditHours: number
       }
     >
-    professorsById: Map<string, { covenantId: string }>
+    professorsById: Map<string, { covenantId: string; displayName?: string }>
     roomsById: Map<string, { abbreviation: string; roomNumber: string }>
     estimatedEnrollmentByKey: Map<string, number>
   },
@@ -78,24 +187,31 @@ function buildBannerRowData(
 
   for (const assignment of assignments) {
     const catalogCourseId = catalogCourseIdOf(assignment.courseId)
-    const course = lookups.coursesById.get(catalogCourseId)
-    const professor =
-      lookups.professorsById.get(assignment.professorId) ??
-      lookups.professorsById.get(assignment.professorId.toLowerCase())
-    const room = lookups.roomsById.get(assignment.roomId)
+    const course = getLookupValue(lookups.coursesById, catalogCourseId)
+    const professor = getLookupValue(
+      lookups.professorsById,
+      assignment.professorId,
+    )
+    const room = getLookupValue(lookups.roomsById, assignment.roomId)
     const normalizedReference = normalizeCourseReference(assignment.courseId)
-    const enrollmentKey = `${assignment.professorId}::${normalizedReference.scheduledCourseId}`
     const estimatedEnrollment =
-      lookups.estimatedEnrollmentByKey.get(enrollmentKey) ??
       lookups.estimatedEnrollmentByKey.get(
-        `${assignment.professorId.toLowerCase()}::${normalizedReference.scheduledCourseId}`,
+        buildEnrollmentKey(
+          assignment.professorId,
+          normalizedReference.scheduledCourseId,
+        ),
       ) ??
       lookups.estimatedEnrollmentByKey.get(
-        `${assignment.professorId}::${normalizedReference.catalogCourseId}`,
-      ) ??
-      lookups.estimatedEnrollmentByKey.get(
-        `${assignment.professorId.toLowerCase()}::${normalizedReference.catalogCourseId}`,
+        buildEnrollmentKey(
+          assignment.professorId,
+          normalizedReference.catalogCourseId,
+        ),
       )
+    const exportRowLabel = [
+      formatExportCourseLabel({ assignment, course }),
+      formatExportProfessorLabel(professor),
+      formatExportRoomLabel(room),
+    ].join(' | ')
 
     const row: BannerRow = {
       Department: course?.deptCode ?? '',
@@ -115,7 +231,7 @@ function buildBannerRowData(
 
     const rowMissing = bannerHeaders.filter((header) => row[header] === '')
     if (rowMissing.length > 0) {
-      missingFields.push(`${assignment.courseId}: ${rowMissing.join(', ')}`)
+      missingFields.push(`${exportRowLabel}: ${rowMissing.join(', ')}`)
       continue
     }
 
@@ -162,17 +278,23 @@ export async function buildScheduleExportFile(
   const courseIds = [
     ...new Set(
       schedule.assignments.map((assignment) =>
-        catalogCourseIdOf(assignment.courseId),
+        normalizeLookupKey(catalogCourseIdOf(assignment.courseId)),
       ),
     ),
   ]
   const professorIds = [
     ...new Set(
-      schedule.assignments.map((assignment) => assignment.professorId),
+      schedule.assignments.map((assignment) =>
+        normalizeLookupKey(assignment.professorId),
+      ),
     ),
   ]
   const roomIds = [
-    ...new Set(schedule.assignments.map((assignment) => assignment.roomId)),
+    ...new Set(
+      schedule.assignments.map((assignment) =>
+        normalizeLookupKey(assignment.roomId),
+      ),
+    ),
   ]
 
   const [courses, professors, rooms] = await Promise.all([
@@ -196,6 +318,7 @@ export async function buildScheduleExportFile(
       {
         _id: 1,
         covenantId: 1,
+        displayName: 1,
         preferences: { $elemMatch: { term: schedule.term } },
       },
     )
@@ -209,24 +332,36 @@ export async function buildScheduleExportFile(
       .exec(),
   ])
 
-  const coursesById = new Map(
-    courses.map((course) => [
-      course._id,
-      {
-        deptCode: course.deptCode,
-        courseNumber: course.courseNumber,
-        title: course.title,
-        creditHours: course.creditHours,
-      },
-    ]),
-  )
-  const professorsById = new Map<string, { covenantId: string }>()
+  const coursesById = new Map<
+    string,
+    {
+      deptCode: string
+      courseNumber: string
+      title: string
+      creditHours: number
+    }
+  >()
+  const professorsById = new Map<
+    string,
+    { covenantId: string; displayName?: string }
+  >()
   const estimatedEnrollmentByKey = new Map<string, number>()
+  for (const course of courses) {
+    const payload = {
+      deptCode: course.deptCode,
+      courseNumber: course.courseNumber,
+      title: course.title,
+      creditHours: course.creditHours,
+    }
+    setLookupAlias(coursesById, course._id, payload)
+  }
   for (const professor of professors) {
-    professorsById.set(professor._id, { covenantId: professor.covenantId })
-    professorsById.set(professor.covenantId, {
+    const payload = {
       covenantId: professor.covenantId,
-    })
+      displayName: professor.displayName,
+    }
+    setLookupAlias(professorsById, professor._id, payload)
+    setLookupAlias(professorsById, professor.covenantId, payload)
 
     for (const submission of professor.preferences ?? []) {
       if (submission.term !== schedule.term) continue
@@ -236,19 +371,31 @@ export async function buildScheduleExportFile(
           coursePreference.section ?? null,
         )
         estimatedEnrollmentByKey.set(
-          `${professor._id}::${normalizedReference.scheduledCourseId}`,
+          buildEnrollmentKey(
+            professor._id,
+            normalizedReference.scheduledCourseId,
+          ),
           coursePreference.expectedEnrollment,
         )
         estimatedEnrollmentByKey.set(
-          `${professor._id}::${normalizedReference.catalogCourseId}`,
+          buildEnrollmentKey(
+            professor._id,
+            normalizedReference.catalogCourseId,
+          ),
           coursePreference.expectedEnrollment,
         )
         estimatedEnrollmentByKey.set(
-          `${professor.covenantId}::${normalizedReference.scheduledCourseId}`,
+          buildEnrollmentKey(
+            professor.covenantId,
+            normalizedReference.scheduledCourseId,
+          ),
           coursePreference.expectedEnrollment,
         )
         estimatedEnrollmentByKey.set(
-          `${professor.covenantId}::${normalizedReference.catalogCourseId}`,
+          buildEnrollmentKey(
+            professor.covenantId,
+            normalizedReference.catalogCourseId,
+          ),
           coursePreference.expectedEnrollment,
         )
       }
@@ -260,14 +407,12 @@ export async function buildScheduleExportFile(
     { abbreviation: string; roomNumber: string }
   >()
   for (const room of rooms) {
-    roomsById.set(room._id, {
+    const payload = {
       abbreviation: room.abbreviation,
       roomNumber: room.roomNumber,
-    })
-    roomsById.set(room.abbreviation, {
-      abbreviation: room.abbreviation,
-      roomNumber: room.roomNumber,
-    })
+    }
+    setLookupAlias(roomsById, room._id, payload)
+    setLookupAlias(roomsById, room.abbreviation, payload)
   }
 
   const rows = buildBannerRowData(schedule.term, schedule.assignments, {

--- a/server/utils/courseReferences.ts
+++ b/server/utils/courseReferences.ts
@@ -24,6 +24,16 @@ function parseEmbeddedSection(normalizedCourseId: string): {
   catalogCourseId: string
   section: string | null
 } {
+  const opaqueMatch = normalizedCourseId.match(/^([a-f0-9]{24})-([A-Z0-9]+)$/i)
+  if (opaqueMatch) {
+    return {
+      catalogCourseId: normalizeCourseIdText(
+        opaqueMatch[1] ?? normalizedCourseId,
+      ),
+      section: normalizeSectionText(opaqueMatch[2] ?? null),
+    }
+  }
+
   const match = normalizedCourseId.match(/^(.+\s+\S+)-([A-Z0-9]+)$/)
   if (!match) {
     return {

--- a/shared/academicTerms.ts
+++ b/shared/academicTerms.ts
@@ -1,0 +1,60 @@
+const TERM_ORDER: Record<string, number> = {
+  winter: 0,
+  spring: 1,
+  summer: 2,
+  fall: 3,
+  autumn: 3,
+}
+
+function normalizeToken(value: string) {
+  return value.trim().toLowerCase()
+}
+
+export function parseAcademicTerm(term: string): {
+  year: number | null
+  semesterOrder: number | null
+} {
+  const normalized = String(term ?? '').trim()
+  if (!normalized) {
+    return { year: null, semesterOrder: null }
+  }
+
+  const tokens = normalized
+    .split(/[^A-Za-z0-9]+/)
+    .map(normalizeToken)
+    .filter(Boolean)
+
+  const yearToken = tokens.find((token) => /^\d{4}$/.test(token))
+  const semesterToken = tokens.find((token) => token in TERM_ORDER)
+
+  return {
+    year: yearToken ? Number(yearToken) : null,
+    semesterOrder: semesterToken ? (TERM_ORDER[semesterToken] ?? null) : null,
+  }
+}
+
+export function compareAcademicTermsDesc(left: string, right: string): number {
+  const leftParsed = parseAcademicTerm(left)
+  const rightParsed = parseAcademicTerm(right)
+
+  if (leftParsed.year !== null && rightParsed.year !== null) {
+    if (leftParsed.year !== rightParsed.year) {
+      return rightParsed.year - leftParsed.year
+    }
+
+    if (
+      leftParsed.semesterOrder !== null &&
+      rightParsed.semesterOrder !== null &&
+      leftParsed.semesterOrder !== rightParsed.semesterOrder
+    ) {
+      return rightParsed.semesterOrder - leftParsed.semesterOrder
+    }
+  } else if (leftParsed.year !== null || rightParsed.year !== null) {
+    return leftParsed.year !== null ? -1 : 1
+  }
+
+  return right.localeCompare(left, undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  })
+}


### PR DESCRIPTION
This PR improves the admin scheduling workflow and related faculty preference polish.

Summary

Resolves Mongo-style schedule references to human-readable course, professor, and room names across schedule review views and export validation.
Tightens schedule_run and schedule_viewer table layouts so content stays inside cards, uses fixed-height preview cells, and supports pop-out details for longer values.
Keeps exported schedules viewable while preserving their locked, non-editable behavior.
Sorts schedule terms by academic year/semester so the newest terms consistently appear first.
Improves faculty preference entry UX by lightening example text and replacing the AM/PM toggle with a compact dropdown.
Files touched

app/pages/admin/schedule_run.vue
app/pages/admin/schedule_viewer.vue
app/utils/schedule.ts
server/services/scheduling/scheduleExport.ts
server/utils/courseReferences.ts
server/api/schedule/index.get.ts
server/api/schedule/terms.get.ts
app/pages/faculty/preferences.vue
app/assets/css/global.css