### PR TITLE
Normalize scheduling room references and improve preference viewer term/course labels

### DIFF
--- a/app/pages/admin/preference_viewer.vue
+++ b/app/pages/admin/preference_viewer.vue
@@ -471,8 +471,7 @@ async function loadAvailableTerms() {
 
     const existingTerm = termInput.value.trim()
     availableTerms.value = existingTerm ? [existingTerm] : []
-    errorMessage.value =
-      `${msg} Retry loading terms or enter one manually to continue.`
+    errorMessage.value = `${msg} Retry loading terms or enter one manually to continue.`
 
     if (typeof window !== 'undefined' && !existingTerm) {
       const manualTerm = window.prompt(
@@ -483,8 +482,7 @@ async function loadAvailableTerms() {
       if (normalizedTerm) {
         termInput.value = normalizedTerm
         availableTerms.value = [normalizedTerm]
-        errorMessage.value =
-          `${msg} Using manually entered term "${normalizedTerm}".`
+        errorMessage.value = `${msg} Using manually entered term "${normalizedTerm}".`
       }
     }
   } finally {

--- a/app/pages/admin/preference_viewer.vue
+++ b/app/pages/admin/preference_viewer.vue
@@ -459,8 +459,34 @@ async function loadAvailableTerms() {
       const [latestTerm] = availableTerms.value
       termInput.value = latestTerm ?? ''
     }
-  } catch {
-    availableTerms.value = []
+  } catch (err: unknown) {
+    const msg =
+      err &&
+      typeof err === 'object' &&
+      'data' in err &&
+      typeof (err as { data?: { statusMessage?: string } }).data
+        ?.statusMessage === 'string'
+        ? (err as { data: { statusMessage: string } }).data.statusMessage
+        : 'Failed to load available terms.'
+
+    const existingTerm = termInput.value.trim()
+    availableTerms.value = existingTerm ? [existingTerm] : []
+    errorMessage.value =
+      `${msg} Retry loading terms or enter one manually to continue.`
+
+    if (typeof window !== 'undefined' && !existingTerm) {
+      const manualTerm = window.prompt(
+        `${msg}\nEnter a term manually to continue:`,
+        '',
+      )
+      const normalizedTerm = manualTerm?.trim() ?? ''
+      if (normalizedTerm) {
+        termInput.value = normalizedTerm
+        availableTerms.value = [normalizedTerm]
+        errorMessage.value =
+          `${msg} Using manually entered term "${normalizedTerm}".`
+      }
+    }
   } finally {
     termsPending.value = false
   }

--- a/app/pages/admin/preference_viewer.vue
+++ b/app/pages/admin/preference_viewer.vue
@@ -7,12 +7,20 @@
       <div class="filter-grid" style="grid-template-columns: 1fr">
         <label>
           Term *
-          <input
-            v-model="termInput"
-            type="text"
-            placeholder="e.g. Fall-2026"
-            @keydown.enter="loadPreferences"
-          />
+          <select v-model="termInput" :disabled="termsPending || pending">
+            <option value="" disabled>
+              {{
+                termsPending
+                  ? 'Loading terms...'
+                  : availableTerms.length > 0
+                    ? 'Select a term'
+                    : 'No terms available'
+              }}
+            </option>
+            <option v-for="term in availableTerms" :key="term" :value="term">
+              {{ term }}
+            </option>
+          </select>
         </label>
         <label>
           Department
@@ -43,7 +51,7 @@
       <div class="filter-actions">
         <button
           class="btn-primary"
-          :disabled="pending"
+          :disabled="pending || termsPending || !termInput"
           @click="loadPreferences"
         >
           {{ pending ? 'Loading…' : 'Load' }}
@@ -68,7 +76,9 @@
         <button @click="loadPreferences">Retry</button>
       </div>
       <div v-else-if="!loadedTerm" class="empty-prompt">
-        <p>Enter a term and click <strong>Load</strong> to view submissions.</p>
+        <p>
+          Select a term and click <strong>Load</strong> to view submissions.
+        </p>
       </div>
       <div v-else class="table-container">
         <table>
@@ -150,7 +160,7 @@
             </thead>
             <tbody>
               <tr v-for="(c, i) in detailSub.courses" :key="i">
-                <td>{{ c.courseId }}</td>
+                <td>{{ courseLabel(c) }}</td>
                 <td>{{ fmt(c.crn) }}</td>
                 <td>{{ fmt(c.section) }}</td>
                 <td>{{ c.title }}</td>
@@ -160,7 +170,7 @@
                 <td>{{ (c.preferredTimes ?? []).join(', ') || '—' }}</td>
                 <td>{{ fmt(c.instructor) }}</td>
                 <td>{{ fmt(c.preferredBuilding) }}</td>
-                <td>{{ fmt(c.preferredRoomId) }}</td>
+                <td>{{ roomLabelForPreference(c.preferredRoomId) }}</td>
                 <td>
                   {{
                     c.courseFee != null
@@ -188,6 +198,21 @@ definePageMeta({
 })
 
 type StatusFilter = 'any' | 'submitted' | 'not_submitted'
+
+type CourseRecord = {
+  _id: string
+  deptCode: string
+  courseNumber: string
+  title: string
+}
+
+type RoomRecord = {
+  _id: string
+  abbreviation?: string | null
+  buildingName?: string | null
+  roomNumber: string
+  displayName?: string | null
+}
 
 type CoursePreference = {
   courseId: string
@@ -218,12 +243,22 @@ type PreferenceSubmission = {
   courses: CoursePreference[]
 }
 
+type ScheduleTermEntry = {
+  term: string
+  hasPreferences: boolean
+}
+
 const termInput = ref('')
 const loadedTerm = ref('')
 const submissions = ref<PreferenceSubmission[]>([])
 const pending = ref(false)
+const termsPending = ref(false)
 const errorMessage = ref('')
 const detailSub = ref<PreferenceSubmission | null>(null)
+const courses = ref<CourseRecord[]>([])
+const rooms = ref<RoomRecord[]>([])
+const availableTerms = ref<string[]>([])
+let referenceLoadPromise: Promise<void> | null = null
 
 const createDefaultFilters = () => ({
   department: '',
@@ -232,6 +267,134 @@ const createDefaultFilters = () => ({
 })
 
 const filters = reactive(createDefaultFilters())
+
+function normalizeLookupValue(value: string | null | undefined): string {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, ' ')
+}
+
+function looksLikeOpaqueId(value: string): boolean {
+  return /^[a-f0-9]{24}$/i.test(value)
+}
+
+function normalizeCourseIdText(value: string): string {
+  const normalized = normalizeWhitespace(value)
+  return looksLikeOpaqueId(normalized) ? normalized : normalized.toUpperCase()
+}
+
+function normalizeSectionText(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  const normalized = normalizeWhitespace(String(value)).toUpperCase()
+  return normalized.length > 0 ? normalized : null
+}
+
+function parseEmbeddedSection(normalizedCourseId: string): {
+  catalogCourseId: string
+  section: string | null
+} {
+  const opaqueMatch = normalizedCourseId.match(/^([a-f0-9]{24})-([A-Z0-9]+)$/i)
+  if (opaqueMatch) {
+    return {
+      catalogCourseId: normalizeCourseIdText(
+        opaqueMatch[1] ?? normalizedCourseId,
+      ),
+      section: normalizeSectionText(opaqueMatch[2] ?? null),
+    }
+  }
+
+  const match = normalizedCourseId.match(/^(.+\s+\S+)-([A-Z0-9]+)$/)
+  if (!match) {
+    return {
+      catalogCourseId: normalizedCourseId,
+      section: null,
+    }
+  }
+
+  return {
+    catalogCourseId: normalizeCourseIdText(match[1] ?? normalizedCourseId),
+    section: normalizeSectionText(match[2] ?? null),
+  }
+}
+
+function normalizeCourseReference(
+  courseId: string,
+  section?: string | null,
+): {
+  catalogCourseId: string
+  section: string | null
+} {
+  const rawCourseId = normalizeCourseIdText(courseId)
+  const normalizedSection = normalizeSectionText(section)
+
+  if (normalizedSection !== null) {
+    const suffix = `-${normalizedSection}`
+    const catalogCourseId = rawCourseId.endsWith(suffix)
+      ? normalizeCourseIdText(rawCourseId.slice(0, -suffix.length))
+      : rawCourseId
+
+    return {
+      catalogCourseId,
+      section: normalizedSection,
+    }
+  }
+
+  return parseEmbeddedSection(rawCourseId)
+}
+
+function subjectLabel(course: CourseRecord): string {
+  return [course.deptCode, course.courseNumber].filter(Boolean).join(' ')
+}
+
+function roomDisplayLabel(room: RoomRecord): string {
+  return (
+    room.abbreviation ||
+    room.displayName ||
+    [room.buildingName, room.roomNumber].filter(Boolean).join(' ')
+  )
+}
+
+const courseLookup = computed(() => {
+  const lookup = new Map<string, CourseRecord>()
+
+  for (const course of courses.value) {
+    for (const key of [course._id, subjectLabel(course)]) {
+      const normalized = normalizeLookupValue(key)
+      if (normalized) {
+        lookup.set(normalized, course)
+      }
+    }
+  }
+
+  return lookup
+})
+
+const roomLookup = computed(() => {
+  const lookup = new Map<string, RoomRecord>()
+
+  for (const room of rooms.value) {
+    for (const key of [
+      room._id,
+      room.abbreviation ?? null,
+      room.displayName ?? null,
+      [room.buildingName, room.roomNumber].filter(Boolean).join(' '),
+    ]) {
+      const normalized = normalizeLookupValue(key)
+      if (normalized) {
+        lookup.set(normalized, room)
+      }
+    }
+  }
+
+  return lookup
+})
 
 const filtered = computed(() =>
   submissions.value.filter((s) => {
@@ -254,6 +417,55 @@ const filtered = computed(() =>
   }),
 )
 
+async function ensureReferenceData() {
+  if (courses.value.length > 0 && rooms.value.length > 0) {
+    return
+  }
+
+  if (!referenceLoadPromise) {
+    referenceLoadPromise = Promise.all([
+      $fetch<CourseRecord[]>('/api/courses', {
+        headers: { 'x-dev-role': 'Admin' },
+      }),
+      $fetch<RoomRecord[]>('/api/rooms', {
+        headers: { 'x-dev-role': 'Admin' },
+      }),
+    ])
+      .then(([fetchedCourses, fetchedRooms]) => {
+        courses.value = fetchedCourses
+        rooms.value = fetchedRooms
+      })
+      .finally(() => {
+        referenceLoadPromise = null
+      })
+  }
+
+  await referenceLoadPromise
+}
+
+async function loadAvailableTerms() {
+  termsPending.value = true
+
+  try {
+    const entries = await $fetch<ScheduleTermEntry[]>('/api/schedule/terms', {
+      headers: { 'x-dev-role': 'Admin' },
+    })
+
+    availableTerms.value = entries
+      .filter((entry) => entry.hasPreferences)
+      .map((entry) => entry.term)
+
+    if (!termInput.value && availableTerms.value.length > 0) {
+      const [latestTerm] = availableTerms.value
+      termInput.value = latestTerm ?? ''
+    }
+  } catch {
+    availableTerms.value = []
+  } finally {
+    termsPending.value = false
+  }
+}
+
 async function loadPreferences() {
   const term = termInput.value.trim()
   if (!term) {
@@ -265,10 +477,13 @@ async function loadPreferences() {
   submissions.value = []
   loadedTerm.value = ''
   try {
-    const res = await $fetch<PreferenceSubmission | PreferenceSubmission[]>(
-      `/api/preferences/${encodeURIComponent(term)}`,
-      { headers: { 'x-dev-role': 'Admin' } },
-    )
+    const [res] = await Promise.all([
+      $fetch<PreferenceSubmission | PreferenceSubmission[]>(
+        `/api/preferences/${encodeURIComponent(term)}`,
+        { headers: { 'x-dev-role': 'Admin' } },
+      ),
+      ensureReferenceData().catch(() => undefined),
+    ])
     submissions.value = Array.isArray(res) ? res : res ? [res] : []
     loadedTerm.value = term
   } catch (err: unknown) {
@@ -312,6 +527,34 @@ function formatDate(value?: string | null) {
 function fmt(value?: string | null) {
   return value?.trim() || '—'
 }
+
+function courseLabel(course: CoursePreference) {
+  const normalized = normalizeCourseReference(
+    course.courseId,
+    course.section ?? null,
+  )
+  const record =
+    courseLookup.value.get(normalizeLookupValue(normalized.catalogCourseId)) ??
+    courseLookup.value.get(normalizeLookupValue(course.courseId))
+
+  if (!record) {
+    return fmt(course.courseId)
+  }
+
+  const label = subjectLabel(record)
+  return normalized.section ? `${label}-${normalized.section}` : label
+}
+
+function roomLabelForPreference(value?: string | null) {
+  if (!value) return 'N/A'
+
+  const room = roomLookup.value.get(normalizeLookupValue(value))
+  return room ? roomDisplayLabel(room) : fmt(value)
+}
+
+onMounted(() => {
+  void loadAvailableTerms()
+})
 
 const { redirectToLogin, redirectToAdmin } = useDebugNavigation()
 </script>

--- a/server/services/scheduling/phases/phase1-collect.ts
+++ b/server/services/scheduling/phases/phase1-collect.ts
@@ -148,10 +148,42 @@ function mergeUniqueStrings(
   return [...new Set(lists.flatMap((list) => list ?? []))]
 }
 
+function normalizeRoomReference(value: string | null | undefined): string {
+  return String(value ?? '')
+    .trim()
+    .toUpperCase()
+}
+
+function resolveRoomReferenceToId(
+  rooms: Room[],
+  roomReference: string | null | undefined,
+): string | null {
+  const normalizedReference = normalizeRoomReference(roomReference)
+  if (!normalizedReference) {
+    return null
+  }
+
+  const matchedRoom =
+    rooms.find((room) =>
+      [
+        room._id,
+        room.abbreviation ?? null,
+        room.displayName ?? null,
+        `${room.buildingCode} ${room.roomNumber}`,
+      ].some(
+        (candidate) =>
+          normalizeRoomReference(candidate) === normalizedReference,
+      ),
+    ) ?? null
+
+  return matchedRoom?._id ?? null
+}
+
 function buildWorkItem(
   course: Awaited<ReturnType<typeof fetchCourses>>[number],
   professor: Professor,
   preference: PreferenceRecord | null,
+  rooms: Room[],
   historicalAssignments: HistoricalAssignment[],
   professorHistory: HistoricalAssignment[],
   similarProfessorHistory: HistoricalAssignment[],
@@ -164,11 +196,20 @@ function buildWorkItem(
   warnings: string[],
 ): CourseWorkItem {
   const preferenceCourses = preference ?? null
+  const resolvedPreferredRoomId = resolveRoomReferenceToId(
+    rooms,
+    preferenceCourses?.preferredRoomId ?? null,
+  )
   const effectivePreference = preferenceCourses
-    ? normalizeCoursePreferences(preferenceCourses)
+    ? {
+        ...normalizeCoursePreferences(preferenceCourses),
+        preferredRoomId:
+          resolvedPreferredRoomId ??
+          normalizeCoursePreferences(preferenceCourses).preferredRoomId,
+      }
     : null
   const hasSubmittedRoomBuildingPreference =
-    (preferenceCourses?.preferredRoomId ?? null) !== null ||
+    resolvedPreferredRoomId !== null ||
     (preferenceCourses?.preferredBuilding ?? null) !== null
   const hasDirectRoomHistory =
     historicalAssignments.length > 0 || professorHistory.length > 0
@@ -221,7 +262,7 @@ function buildWorkItem(
       effectivePreference?.requiredEquipment,
     ),
     preferredBuilding: effectivePreference?.preferredBuilding ?? null,
-    preferredRoomId: effectivePreference?.preferredRoomId ?? null,
+    preferredRoomId: resolvedPreferredRoomId ?? null,
     backToBackWith: effectivePreference?.backToBackWith ?? null,
     preferredBackToBackWith: [],
     coreqWith: mergeUniqueStrings(
@@ -578,6 +619,7 @@ export async function collectInputs(term: string): Promise<CollectedInputs> {
           course,
           professor,
           preference,
+          rooms,
           historicalAssignments.slice(0, schedulingConfig.maxHistoryPerCourse),
           professorHistory,
           similarProfessorHistory,

--- a/server/services/scheduling/scheduleExport.ts
+++ b/server/services/scheduling/scheduleExport.ts
@@ -53,6 +53,22 @@ function normalizeLookupKey(value: string): string {
     : normalized
 }
 
+function expandQueryKeys(value: string | null | undefined): string[] {
+  if (!value) return []
+
+  const normalized = normalizeWhitespace(String(value))
+  if (!normalized) return []
+
+  return [
+    ...new Set([
+      normalized,
+      normalized.toLowerCase(),
+      normalized.toUpperCase(),
+      normalizeLookupKey(normalized),
+    ]),
+  ]
+}
+
 function setLookupAlias<Value>(
   map: Map<string, Value>,
   key: string | null | undefined,
@@ -149,16 +165,23 @@ function formatExportProfessorLabel(professor?: {
   return 'Unresolved professor'
 }
 
-function formatExportRoomLabel(room?: {
-  abbreviation: string
-  roomNumber: string
-}) {
+function formatExportRoomLabel(
+  room?: {
+    abbreviation: string
+    roomNumber: string
+  },
+  roomId?: string,
+) {
   if (room?.abbreviation) {
     return room.abbreviation
   }
 
   if (room?.roomNumber) {
     return `Room ${room.roomNumber}`
+  }
+
+  if (roomId && !looksLikeOpaqueReference(roomId)) {
+    return roomId
   }
 
   return 'Unresolved room'
@@ -210,7 +233,7 @@ function buildBannerRowData(
     const exportRowLabel = [
       formatExportCourseLabel({ assignment, course }),
       formatExportProfessorLabel(professor),
-      formatExportRoomLabel(room),
+      formatExportRoomLabel(room, assignment.roomId),
     ].join(' | ')
 
     const row: BannerRow = {
@@ -277,22 +300,22 @@ export async function buildScheduleExportFile(
 
   const courseIds = [
     ...new Set(
-      schedule.assignments.map((assignment) =>
-        normalizeLookupKey(catalogCourseIdOf(assignment.courseId)),
+      schedule.assignments.flatMap((assignment) =>
+        expandQueryKeys(catalogCourseIdOf(assignment.courseId)),
       ),
     ),
   ]
   const professorIds = [
     ...new Set(
-      schedule.assignments.map((assignment) =>
-        normalizeLookupKey(assignment.professorId),
+      schedule.assignments.flatMap((assignment) =>
+        expandQueryKeys(assignment.professorId),
       ),
     ),
   ]
   const roomIds = [
     ...new Set(
-      schedule.assignments.map((assignment) =>
-        normalizeLookupKey(assignment.roomId),
+      schedule.assignments.flatMap((assignment) =>
+        expandQueryKeys(assignment.roomId),
       ),
     ),
   ]
@@ -325,8 +348,14 @@ export async function buildScheduleExportFile(
       .lean()
       .exec(),
     Room.find(
-      { $or: [{ _id: { $in: roomIds } }, { abbreviation: { $in: roomIds } }] },
-      { _id: 1, abbreviation: 1, roomNumber: 1 },
+      {
+        $or: [
+          { _id: { $in: roomIds } },
+          { abbreviation: { $in: roomIds } },
+          { displayName: { $in: roomIds } },
+        ],
+      },
+      { _id: 1, abbreviation: 1, roomNumber: 1, displayName: 1 },
     )
       .lean()
       .exec(),
@@ -413,6 +442,7 @@ export async function buildScheduleExportFile(
     }
     setLookupAlias(roomsById, room._id, payload)
     setLookupAlias(roomsById, room.abbreviation, payload)
+    setLookupAlias(roomsById, room.displayName, payload)
   }
 
   const rows = buildBannerRowData(schedule.term, schedule.assignments, {

--- a/server/services/scheduling/scheduleExport.ts
+++ b/server/services/scheduling/scheduleExport.ts
@@ -357,6 +357,7 @@ export async function buildScheduleExportFile(
       },
       { _id: 1, abbreviation: 1, roomNumber: 1, displayName: 1 },
     )
+      .collation({ locale: 'en', strength: 2 })
       .lean()
       .exec(),
   ])

--- a/server/services/scheduling/utils/history.ts
+++ b/server/services/scheduling/utils/history.ts
@@ -48,12 +48,45 @@ function normalizeRoomDisplayName(
   return normalized.length > 0 ? normalized : null
 }
 
+function normalizeRoomReference(
+  value: string | null | undefined,
+): string | null {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase()
+  return normalized.length > 0 ? normalized : null
+}
+
+function roomReferenceAliases(room: Room): string[] {
+  const aliases = new Set<string>()
+
+  for (const value of [
+    room._id,
+    room.abbreviation ?? null,
+    room.displayName ?? null,
+    `${room.buildingCode} ${room.roomNumber}`,
+  ]) {
+    const normalized = normalizeRoomReference(value)
+    if (normalized !== null) {
+      aliases.add(normalized)
+    }
+  }
+
+  return [...aliases]
+}
+
 function roomMatchesPreference(
   room: Room,
   preferredRoomId: string | null,
   preferredBuilding: string | null,
 ): boolean {
-  if (preferredRoomId !== null && preferredRoomId === room._id) {
+  const normalizedPreferredRoom = normalizeRoomReference(preferredRoomId)
+  if (
+    normalizedPreferredRoom !== null &&
+    roomReferenceAliases(room).includes(normalizedPreferredRoom)
+  ) {
     return true
   }
 
@@ -206,14 +239,20 @@ export function hasRealDataForRoom(
   if (
     input.historicalAssignments.some(
       (assignment) =>
-        assignment.roomId === room._id ||
-        assignment.buildingCode === room.buildingCode,
+        roomReferenceAliases(room).includes(
+          normalizeRoomReference(assignment.roomId) ?? '',
+        ) || assignment.buildingCode === room.buildingCode,
     )
   ) {
     return true
   }
 
-  if ((input.historicalPreferredRoomIds ?? []).includes(room._id)) {
+  const roomAliases = roomReferenceAliases(room)
+  if (
+    (input.historicalPreferredRoomIds ?? []).some((roomId) =>
+      roomAliases.includes(normalizeRoomReference(roomId) ?? ''),
+    )
+  ) {
     return true
   }
 


### PR DESCRIPTION
This PR hardens scheduling/export behavior around legacy room references and improves the admin preference review experience.

Summary

Normalizes faculty preference room references to canonical room IDs before scheduling so abbreviations, display labels, and stored IDs all resolve consistently.
Expands guarded-room/history matching to treat room _id, abbreviation, display name, and building-room labels as equivalent references.
Hardens schedule export lookups to resolve course/professor/room references across case variants and room display names, improving legacy export compatibility.
Replaces the admin preference viewer’s free-text term input with a dropdown of available preference-backed terms, newest first.
Resolves raw course and room IDs in the admin “View Courses” modal to human-readable subject and room labels.
Files changed

app/pages/admin/preference_viewer.vue
server/services/scheduling/phases/phase1-collect.ts
server/services/scheduling/utils/history.ts
server/services/scheduling/scheduleExport.ts