### PR TITLE
Potential Export Fix, small Qol changes

### DIFF
--- a/app/assets/css/room-viewer.css
+++ b/app/assets/css/room-viewer.css
@@ -20,6 +20,7 @@
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  overflow-x: hidden;
   min-height: 0;
   margin-bottom: 3rem;
 }
@@ -51,9 +52,10 @@
 /* Filter Grid */
 .filter-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(135px, 1fr));
   gap: 0.75rem;
   flex: 1;
+  min-width: 0;
 }
 
 .filter-grid label,
@@ -61,9 +63,10 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   font-weight: 500;
   color: var(--color-text-primary);
+  min-width: 0;
 }
 
 .filter-grid input,
@@ -76,7 +79,11 @@
   color: var(--color-text-primary);
   border-radius: 6px;
   padding: 0.5rem;
-  font-size: 0.95rem;
+  font-size: 0.75rem;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .filter-grid input:focus-visible,

--- a/app/pages/admin/schedule_viewer.vue
+++ b/app/pages/admin/schedule_viewer.vue
@@ -352,59 +352,133 @@
                     No schedule rows match the current filters.
                   </div>
                 </template>
-                <Column field="department" header="Dept" sortable>
+                <Column
+                  field="department"
+                  header="Dept"
+                  sortable
+                  :style="{ width: '6.5rem' }"
+                >
                   <template #body="{ data }">
                     <ScheduleCellPreview
-                      :value="data.department"
+                      :value="
+                        isEditingRow(data.courseId)
+                          ? editedCourseDepartment
+                          : data.department
+                      "
                       title="Department"
+                      :max-lines="1"
                     />
                   </template>
                 </Column>
-                <Column field="courseNumber" header="Course" sortable>
+                <Column
+                  field="courseNumber"
+                  header="Course"
+                  sortable
+                  :style="{ width: '9rem' }"
+                >
                   <template #body="{ data }">
                     <ScheduleCellPreview
+                      v-if="!isEditingRow(data.courseId)"
                       :value="data.courseNumber"
                       title="Course"
+                      :max-lines="1"
                     />
+                    <select
+                      v-else
+                      v-model="editCourseCatalogId"
+                      class="schedule-native-select"
+                    >
+                      <option value="" disabled>Select course</option>
+                      <option
+                        v-for="option in editableCourseOptions"
+                        :key="option.value"
+                        :value="option.value"
+                      >
+                        {{ option.label }}
+                      </option>
+                    </select>
                   </template>
                 </Column>
-                <Column field="section" header="Section" sortable>
+                <Column
+                  field="section"
+                  header="Section"
+                  sortable
+                  :style="{ width: '6rem' }"
+                >
                   <template #body="{ data }">
                     <ScheduleCellPreview
+                      v-if="!isEditingRow(data.courseId)"
                       :value="data.section || 'N/A'"
                       title="Section"
+                      :max-lines="1"
+                    />
+                    <InputText
+                      v-else
+                      v-model="editCourseSection"
+                      fluid
+                      placeholder="section"
                     />
                   </template>
                 </Column>
-                <Column field="courseTitle" header="Title" sortable>
+                <Column
+                  field="courseTitle"
+                  header="Title"
+                  sortable
+                  :style="{ width: '16rem' }"
+                >
                   <template #body="{ data }">
                     <ScheduleCellPreview
-                      :value="data.courseTitle"
+                      :value="
+                        isEditingRow(data.courseId)
+                          ? editedCourseTitle
+                          : data.courseTitle
+                      "
                       title="Course Title"
+                      :max-lines="1"
                     />
                   </template>
                 </Column>
-                <Column field="instructorName" header="Instructor" sortable>
+                <Column
+                  field="instructorName"
+                  header="Instructor"
+                  sortable
+                  :style="{ width: '14rem' }"
+                >
                   <template #body="{ data }">
                     <ScheduleCellPreview
                       v-if="!isEditingRow(data.courseId)"
                       :value="data.instructorName"
                       title="Instructor"
+                      :max-lines="1"
                     />
-                    <InputText
+                    <select
                       v-else
                       v-model="editDraft.professorId"
-                      fluid
-                      placeholder="professor id"
-                    />
+                      class="schedule-native-select"
+                    >
+                      <option value="" disabled>Select instructor</option>
+                      <option
+                        v-for="option in editableInstructorOptions"
+                        :key="option.value"
+                        :value="option.value"
+                      >
+                        {{ option.label }}
+                      </option>
+                    </select>
                   </template>
                 </Column>
-                <Column field="timeLabel" header="Time" sortable>
+                <Column
+                  field="timeLabel"
+                  header="Time"
+                  sortable
+                  :style="{ width: '11rem' }"
+                >
                   <template #body="{ data }">
                     <ScheduleCellPreview
                       v-if="!isEditingRow(data.courseId)"
                       :value="data.timeLabel"
                       title="Time"
+                      :max-lines="1"
                     />
                     <div v-else class="schedule-edit-time">
                       <select
@@ -432,46 +506,91 @@
                     </div>
                   </template>
                 </Column>
-                <Column field="building" header="Building" sortable>
+                <Column
+                  field="building"
+                  header="Building"
+                  sortable
+                  :style="{ width: '8rem' }"
+                >
                   <template #body="{ data }">
                     <ScheduleCellPreview
-                      :value="data.building"
+                      :value="
+                        isEditingRow(data.courseId)
+                          ? editedRoomBuilding
+                          : data.building
+                      "
                       title="Building"
+                      :max-lines="1"
                     />
                   </template>
                 </Column>
-                <Column field="roomLabel" header="Room" sortable>
+                <Column
+                  field="roomLabel"
+                  header="Room"
+                  sortable
+                  :style="{ width: '10rem' }"
+                >
                   <template #body="{ data }">
                     <ScheduleCellPreview
                       v-if="!isEditingRow(data.courseId)"
                       :value="data.roomLabel"
                       title="Room"
+                      :max-lines="1"
                     />
-                    <InputText
+                    <select
                       v-else
                       v-model="editDraft.roomId"
-                      fluid
-                      placeholder="room id"
-                    />
+                      class="schedule-native-select"
+                    >
+                      <option value="" disabled>Select room</option>
+                      <option
+                        v-for="option in editableRoomOptions"
+                        :key="option.value"
+                        :value="option.value"
+                      >
+                        {{ option.label }}
+                      </option>
+                    </select>
                   </template>
                 </Column>
-                <Column field="enrollment" header="Enroll" sortable>
+                <Column
+                  field="enrollment"
+                  header="Enroll"
+                  sortable
+                  :style="{ width: '7rem' }"
+                >
                   <template #body="{ data }">
                     <ScheduleCellPreview
+                      v-if="!isEditingRow(data.courseId)"
                       :value="data.enrollment ?? 'N/A'"
                       title="Enrollment"
+                      :max-lines="1"
+                    />
+                    <input
+                      v-else
+                      v-model="editEnrollmentValue"
+                      type="number"
+                      min="0"
+                      class="schedule-native-input"
+                      placeholder="enrollment"
                     />
                   </template>
                 </Column>
-                <Column field="overrideBy" header="Override By" sortable>
+                <Column
+                  field="overrideBy"
+                  header="Override By"
+                  sortable
+                  :style="{ width: '11rem' }"
+                >
                   <template #body="{ data }">
                     <ScheduleCellPreview
                       :value="data.overrideBy || 'N/A'"
                       title="Override By"
+                      :max-lines="1"
                     />
                   </template>
                 </Column>
-                <Column header="Actions">
+                <Column header="Actions" :style="{ width: '9rem' }">
                   <template #body="{ data }">
                     <div class="schedule-row-actions">
                       <template v-if="!isEditingRow(data.courseId)">
@@ -778,9 +897,11 @@
 
 <script setup lang="ts">
 import {
+  buildScheduledCourseId,
   buildEnrichedScheduleRows,
   buildIssueTableRows,
   buildTraceTableRows,
+  normalizeCourseReference,
 } from '~~/app/utils/schedule'
 import {
   downloadScheduleExport,
@@ -788,7 +909,8 @@ import {
 } from '~~/app/utils/scheduleExport'
 import { useScheduleReferenceData } from '~~/app/composables/useScheduleReferenceData'
 import type {
-  EnrichedScheduleRow,
+  ProfessorRecord,
+  RoomRecord,
   SavedScheduleDetails,
   SavedScheduleSummary,
   ScheduleAssignment,
@@ -807,6 +929,11 @@ type ScheduleRunResponse = {
   term: string
   count: number
   schedules: SavedScheduleDetails[]
+}
+
+type EditSelectOption = {
+  value: string
+  label: string
 }
 
 const scheduleItems = ref<SavedScheduleSummary[]>([])
@@ -840,8 +967,13 @@ const editDraft = reactive<ScheduleAssignment>({
   days: 'MWF',
   startTime: '',
   endTime: '',
+  enrollmentOverride: null,
   overrideBy: null,
 })
+
+const editCourseCatalogId = ref('')
+const editCourseSection = ref('')
+const editEnrollmentValue = ref('')
 
 const dayPatternOptions: ScheduleAssignment['days'][] = [
   'MWF',
@@ -855,7 +987,8 @@ const dayPatternOptions: ScheduleAssignment['days'][] = [
   'R',
 ]
 
-const { lookups, loadForTerm } = useScheduleReferenceData()
+const { lookups, courses, professors, rooms, loadForTerm } =
+  useScheduleReferenceData()
 
 const schedulesByTerm = computed(() => {
   return termEntries.value.reduce<Record<string, SavedScheduleSummary[]>>(
@@ -986,6 +1119,138 @@ const buildingOptions = computed(() =>
 const roomOptions = computed(() =>
   [...new Set(enrichedRows.value.map((row) => row.roomLabel))].sort(),
 )
+
+function formatEditableCourseLabel(course: {
+  deptCode: string
+  courseNumber: string
+  title: string
+}) {
+  return `${course.deptCode} ${course.courseNumber} - ${course.title}`
+}
+
+function formatEditableInstructorLabel(professor: ProfessorRecord) {
+  const name = professor.displayName?.trim() ?? ''
+  const covenantId = professor.covenantId?.trim() ?? ''
+  return name && covenantId ? `${name} (${covenantId})` : name || covenantId
+}
+
+function formatEditableRoomLabel(room: RoomRecord) {
+  return (
+    room.abbreviation?.trim() ||
+    room.displayName?.trim() ||
+    `${room.buildingName} ${room.roomNumber}`.trim()
+  )
+}
+
+function includeCurrentOption(
+  options: EditSelectOption[],
+  currentValue: string,
+  label: string,
+) {
+  if (
+    !currentValue ||
+    options.some((option) => option.value === currentValue)
+  ) {
+    return options
+  }
+
+  return [{ value: currentValue, label }, ...options]
+}
+
+const editableCourseOptions = computed<EditSelectOption[]>(() => {
+  const options = courses.value
+    .map((course) => ({
+      value: course._id,
+      label: formatEditableCourseLabel(course),
+    }))
+    .sort((left, right) => left.label.localeCompare(right.label))
+
+  const currentValue = editCourseCatalogId.value.trim()
+  const currentCourse = lookups.value.coursesById.get(currentValue)
+  const currentLabel = currentCourse
+    ? formatEditableCourseLabel(currentCourse)
+    : currentValue
+
+  return includeCurrentOption(options, currentValue, currentLabel)
+})
+
+const editableInstructorOptions = computed<EditSelectOption[]>(() => {
+  const options = professors.value
+    .map((professor) => ({
+      value: professor._id,
+      label: formatEditableInstructorLabel(professor),
+    }))
+    .sort((left, right) => left.label.localeCompare(right.label))
+
+  const currentValue = editDraft.professorId.trim()
+  const currentLabel =
+    lookups.value.professorsById.get(currentValue)?.displayName ?? currentValue
+
+  return includeCurrentOption(options, currentValue, currentLabel)
+})
+
+const editedCourseRecord = computed(() => {
+  const currentValue = editCourseCatalogId.value.trim()
+  if (!currentValue) return null
+
+  return (
+    courses.value.find((course) => course._id === currentValue) ??
+    lookups.value.coursesById.get(currentValue) ??
+    null
+  )
+})
+
+const editedCourseDepartment = computed(() => {
+  if (editedCourseRecord.value) {
+    return editedCourseRecord.value.deptCode
+  }
+
+  return normalizeCourseReference(editDraft.courseId).catalogCourseId.split(
+    /\s+/,
+  )[0]
+})
+
+const editedCourseTitle = computed(() => {
+  if (editedCourseRecord.value) {
+    return editedCourseRecord.value.title
+  }
+
+  return normalizeCourseReference(editDraft.courseId).catalogCourseId
+})
+
+const editedRoomRecord = computed(() => {
+  const currentValue = editDraft.roomId.trim()
+  if (!currentValue) return null
+
+  return rooms.value.find((room) => room._id === currentValue) ?? null
+})
+
+const editedRoomBuilding = computed(() => {
+  if (editedRoomRecord.value) {
+    return (
+      editedRoomRecord.value.abbreviation?.split(/\s+/)[0] ||
+      editedRoomRecord.value.buildingName
+    )
+  }
+
+  const fallbackRoom = lookups.value.roomsById.get(editDraft.roomId.trim())
+  return fallbackRoom?.abbreviation?.split(/\s+/)[0] ?? editDraft.roomId
+})
+
+const editableRoomOptions = computed<EditSelectOption[]>(() => {
+  const options = rooms.value
+    .map((room) => ({
+      value: room._id,
+      label: formatEditableRoomLabel(room),
+    }))
+    .sort((left, right) => left.label.localeCompare(right.label))
+
+  const currentValue = editDraft.roomId.trim()
+  const currentLabel =
+    lookups.value.roomsById.get(currentValue)?.abbreviation ?? currentValue
+
+  return includeCurrentOption(options, currentValue, currentLabel)
+})
 
 const hasActiveFilters = computed(() => {
   return Boolean(
@@ -1136,13 +1401,28 @@ function startEdit(courseId: string) {
 
   editingCourseId.value = courseId
   Object.assign(editDraft, assignment)
+  const normalizedCourse = normalizeCourseReference(assignment.courseId)
+  editCourseCatalogId.value = normalizedCourse.catalogCourseId
+  editCourseSection.value = normalizedCourse.section ?? ''
+  editEnrollmentValue.value =
+    assignment.enrollmentOverride !== null &&
+    assignment.enrollmentOverride !== undefined
+      ? String(assignment.enrollmentOverride)
+      : ''
 }
 
 function cancelEdit() {
   editingCourseId.value = null
+  editCourseCatalogId.value = ''
+  editCourseSection.value = ''
+  editEnrollmentValue.value = ''
 }
 
 function validateEditDraft() {
+  if (!editCourseCatalogId.value.trim()) {
+    return 'Please provide a course before saving.'
+  }
+
   const requiredFields: Array<[string, string]> = [
     ['professor', editDraft.professorId],
     ['room', editDraft.roomId],
@@ -1154,6 +1434,14 @@ function validateEditDraft() {
   const missing = requiredFields.find(([, value]) => !value?.trim())
   if (missing) {
     return `Please provide a ${missing[0]} before saving.`
+  }
+
+  const enrollmentText = editEnrollmentValue.value.trim()
+  if (
+    enrollmentText &&
+    (!/^\d+$/.test(enrollmentText) || Number(enrollmentText) < 0)
+  ) {
+    return 'Please provide a non-negative enrollment value.'
   }
 
   return ''
@@ -1170,6 +1458,14 @@ async function saveEdit() {
 
   rowActionPending.value = true
   try {
+    const nextCourseId = buildScheduledCourseId(
+      editCourseCatalogId.value,
+      editCourseSection.value || null,
+    )
+    const enrollmentOverride = editEnrollmentValue.value.trim()
+      ? Number(editEnrollmentValue.value.trim())
+      : null
+
     await $fetch(
       `/api/schedule/${encodeURIComponent(selectedSchedule.value.term)}/assignment`,
       {
@@ -1178,12 +1474,13 @@ async function saveEdit() {
           runNumber: selectedSchedule.value.runNumber,
           originalCourseId: editingCourseId.value,
           assignment: {
-            courseId: editingCourseId.value,
+            courseId: nextCourseId,
             professorId: editDraft.professorId,
             roomId: editDraft.roomId,
             days: editDraft.days,
             startTime: editDraft.startTime,
             endTime: editDraft.endTime,
+            enrollmentOverride,
           },
         },
       },
@@ -1191,6 +1488,9 @@ async function saveEdit() {
 
     await refreshSelectedSchedule()
     editingCourseId.value = null
+    editCourseCatalogId.value = ''
+    editCourseSection.value = ''
+    editEnrollmentValue.value = ''
     setStatus(
       `Updated ${selectedSchedule.value.term} run ${selectedSchedule.value.runNumber}.`,
       'success',
@@ -1484,7 +1784,8 @@ onMounted(async () => {
   color: var(--color-text-secondary);
 }
 
-.schedule-native-select {
+.schedule-native-select,
+.schedule-native-input {
   width: 100%;
   min-height: 2.75rem;
   padding: 0.7rem 0.85rem;
@@ -1492,9 +1793,11 @@ onMounted(async () => {
   border: 1px solid rgba(148, 163, 184, 0.42);
   background: #fff;
   color: var(--color-text-primary);
+  box-sizing: border-box;
 }
 
-.schedule-native-select:focus-visible {
+.schedule-native-select:focus-visible,
+.schedule-native-input:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }

--- a/app/utils/schedule.ts
+++ b/app/utils/schedule.ts
@@ -418,7 +418,7 @@ export function buildEnrichedScheduleRows(
       building: roomBuilding(room),
       roomNumber: room?.roomNumber ?? assignment.roomId,
       roomLabel: roomLabel(room, assignment.roomId),
-      enrollment,
+      enrollment: assignment.enrollmentOverride ?? enrollment,
       days: assignment.days,
       startTime: assignment.startTime,
       endTime: assignment.endTime,

--- a/server/api/schedule/[term]/assignment.patch.ts
+++ b/server/api/schedule/[term]/assignment.patch.ts
@@ -138,6 +138,7 @@ export default defineEventHandler(async (event) => {
     'days',
     'startTime',
     'endTime',
+    'enrollmentOverride',
     'overrideBy',
   ] as const) {
     if (hasOwn(patchSource, field) && patchSource[field] !== undefined) {

--- a/server/api/schedule/[term]/template.get.ts
+++ b/server/api/schedule/[term]/template.get.ts
@@ -50,6 +50,7 @@ export default defineEventHandler(async (event) => {
           days: 'MWF',
           startTime: '09:00',
           endTime: '10:30',
+          enrollmentOverride: null,
           overrideBy: null,
         },
         conflictExample: {
@@ -96,6 +97,7 @@ export default defineEventHandler(async (event) => {
         days: 'MWF',
         startTime: '09:00',
         endTime: '10:30',
+        enrollmentOverride: null,
         overrideBy: null,
       },
       conflictExample: {

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -103,6 +103,7 @@ export interface IAssignment {
   days: DayPattern
   startTime: string
   endTime: string
+  enrollmentOverride?: number | null
   overrideBy?: string | null
 }
 
@@ -362,6 +363,7 @@ const assignmentSchema = new Schema<IAssignment>(
     },
     startTime: { type: String, required: true, trim: true },
     endTime: { type: String, required: true, trim: true },
+    enrollmentOverride: { type: Number, default: null, min: 0 },
     overrideBy: { type: String, default: null, trim: true },
   },
   { _id: false },

--- a/server/services/scheduling/scheduleExport.ts
+++ b/server/services/scheduling/scheduleExport.ts
@@ -7,6 +7,7 @@ import {
   type IAssignment,
   type ISchedule,
 } from '../../models/index'
+import { Users } from '../../models/user.model'
 import {
   catalogCourseIdOf,
   courseSectionOf,
@@ -134,6 +135,10 @@ function getBuildingCode(roomAbbreviation: string): string {
   return roomAbbreviation.split(/\s+/)[0] ?? ''
 }
 
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 function splitRoomReference(roomReference: string | null | undefined): {
   buildingCode: string
   roomNumber: string
@@ -198,6 +203,7 @@ function formatExportProfessorLabel(professor?: {
 function formatExportOverrideLabel(input: {
   overrideBy?: string | null
   professorsById: Map<string, { covenantId: string; displayName?: string }>
+  overrideActorsById: Map<string, string>
 }) {
   const overrideBy = normalizeWhitespace(String(input.overrideBy ?? ''))
   if (!overrideBy) return ''
@@ -207,7 +213,16 @@ function formatExportOverrideLabel(input: {
     return professor.displayName
   }
 
-  return overrideBy
+  const overrideActor = getLookupValue(input.overrideActorsById, overrideBy)
+  if (overrideActor) {
+    return overrideActor
+  }
+
+  if (looksLikeOpaqueReference(overrideBy)) {
+    return 'Administrative override'
+  }
+
+  return `Admin (${overrideBy})`
 }
 
 function formatExportRoomLabel(
@@ -303,6 +318,7 @@ function buildExportRowData(
       }
     >
     professorsById: Map<string, { covenantId: string; displayName?: string }>
+    overrideActorsById: Map<string, string>
     roomsById: Map<string, { abbreviation: string; roomNumber: string }>
     preferenceFieldsByKey: Map<string, PreferenceExportFields>
   },
@@ -367,6 +383,7 @@ function buildExportRowData(
       OverrideBy: formatExportOverrideLabel({
         overrideBy: assignment.overrideBy,
         professorsById: lookups.professorsById,
+        overrideActorsById: lookups.overrideActorsById,
       }),
     }
 
@@ -412,9 +429,10 @@ export async function buildScheduleExportFile(
   ]
   const professorIds = [
     ...new Set(
-      schedule.assignments.flatMap((assignment) =>
-        expandQueryKeys(assignment.professorId),
-      ),
+      schedule.assignments.flatMap((assignment) => [
+        ...expandQueryKeys(assignment.professorId),
+        ...expandQueryKeys(assignment.overrideBy),
+      ]),
     ),
   ]
   const roomIds = [
@@ -424,8 +442,15 @@ export async function buildScheduleExportFile(
       ),
     ),
   ]
+  const overrideIds = [
+    ...new Set(
+      schedule.assignments.flatMap((assignment) =>
+        expandQueryKeys(assignment.overrideBy),
+      ),
+    ),
+  ]
 
-  const [courses, professors, rooms] = await Promise.all([
+  const [courses, professors, rooms, users] = await Promise.all([
     CourseCatalog.find(
       { _id: { $in: courseIds } },
       { _id: 1, deptCode: 1, courseNumber: 1, title: 1, creditHours: 1 },
@@ -465,6 +490,21 @@ export async function buildScheduleExportFile(
       .collation({ locale: 'en', strength: 2 })
       .lean()
       .exec(),
+    overrideIds.length
+      ? Users.find(
+          {
+            $or: [
+              { username: { $in: overrideIds } },
+              ...overrideIds.map((id) => ({
+                email: { $regex: `^${escapeRegex(id)}@`, $options: 'i' },
+              })),
+            ],
+          } as any,
+          { _id: 1, username: 1, email: 1, name: 1, preferred: 1 } as any,
+        )
+          .lean()
+          .exec()
+      : Promise.resolve([]),
   ])
 
   const coursesById = new Map<
@@ -480,6 +520,7 @@ export async function buildScheduleExportFile(
     string,
     { covenantId: string; displayName?: string }
   >()
+  const overrideActorsById = new Map<string, string>()
   const preferenceFieldsByKey = new Map<string, PreferenceExportFields>()
   for (const course of courses) {
     const payload = {
@@ -498,6 +539,14 @@ export async function buildScheduleExportFile(
     setLookupAlias(professorsById, professor._id, payload)
     setLookupAlias(professorsById, professor.covenantId, payload)
     setLookupAlias(professorsById, professor.displayName, payload)
+    if (professor.displayName) {
+      setLookupAlias(overrideActorsById, professor._id, professor.displayName)
+      setLookupAlias(
+        overrideActorsById,
+        professor.covenantId,
+        professor.displayName,
+      )
+    }
 
     for (const submission of professor.preferences ?? []) {
       if (submission.term !== schedule.term) continue
@@ -539,6 +588,22 @@ export async function buildScheduleExportFile(
     }
   }
 
+  for (const user of users) {
+    const displayName =
+      normalizeWhitespace(String(user.preferred ?? '')) ||
+      normalizeWhitespace(String(user.name ?? '')) ||
+      normalizeWhitespace(String(user.username ?? ''))
+
+    if (!displayName) continue
+
+    setLookupAlias(overrideActorsById, user.username, displayName)
+
+    const email = normalizeWhitespace(String(user.email ?? ''))
+    if (email.includes('@')) {
+      setLookupAlias(overrideActorsById, email.split('@')[0], displayName)
+    }
+  }
+
   const roomsById = new Map<
     string,
     { abbreviation: string; roomNumber: string }
@@ -556,6 +621,7 @@ export async function buildScheduleExportFile(
   const rows = buildExportRowData(schedule.assignments, {
     coursesById,
     professorsById,
+    overrideActorsById,
     roomsById,
     preferenceFieldsByKey,
   })

--- a/server/services/scheduling/scheduleExport.ts
+++ b/server/services/scheduling/scheduleExport.ts
@@ -21,22 +21,27 @@ type ExportSchedule = Pick<
   '_id' | 'term' | 'runNumber' | 'status' | 'assignments'
 >
 
-const bannerHeaders = [
+const exportHeaders = [
   'Department',
-  'CourseNumber',
+  'Course',
   'Section',
   'Title',
   'CreditHours',
-  'ProfessorCovenantId',
+  'CRN',
+  'CourseFee',
+  'Instructor',
+  'InstructorCovenantId',
   'Days',
   'StartTime',
   'EndTime',
-  'BuildingCode',
-  'RoomNumber',
+  'Time',
+  'Building',
+  'Room',
   'EstimatedEnrollment',
+  'OverrideBy',
 ] as const
 
-type BannerRow = Record<(typeof bannerHeaders)[number], string | number>
+type ExportRow = Record<(typeof exportHeaders)[number], string | number>
 
 function normalizeWhitespace(value: string): string {
   return value.trim().replace(/\s+/g, ' ')
@@ -104,6 +109,12 @@ function getLookupValue<Value>(
 
 function buildEnrollmentKey(professorKey: string, courseKey: string) {
   return `${normalizeLookupKey(professorKey)}::${normalizeLookupKey(courseKey)}`
+}
+
+type PreferenceExportFields = {
+  estimatedEnrollment: number | null
+  crn: string | null
+  courseFee: number | null
 }
 
 async function loadXlsxModule() {
@@ -184,6 +195,21 @@ function formatExportProfessorLabel(professor?: {
   return 'Unresolved professor'
 }
 
+function formatExportOverrideLabel(input: {
+  overrideBy?: string | null
+  professorsById: Map<string, { covenantId: string; displayName?: string }>
+}) {
+  const overrideBy = normalizeWhitespace(String(input.overrideBy ?? ''))
+  if (!overrideBy) return ''
+
+  const professor = getLookupValue(input.professorsById, overrideBy)
+  if (professor?.displayName) {
+    return professor.displayName
+  }
+
+  return overrideBy
+}
+
 function formatExportRoomLabel(
   room?: {
     abbreviation: string
@@ -204,6 +230,17 @@ function formatExportRoomLabel(
   }
 
   return 'Unresolved room'
+}
+
+function formatExportTimeLabel(assignment: IAssignment) {
+  const parts = [
+    assignment.days ?? '',
+    [assignment.startTime ?? '', assignment.endTime ?? '']
+      .filter(Boolean)
+      .join('-'),
+  ].filter(Boolean)
+
+  return parts.join(' ')
 }
 
 function fallbackCourseFields(
@@ -253,8 +290,7 @@ function fallbackRoomFields(
   return splitRoomReference(assignment.roomId)
 }
 
-function buildBannerRowData(
-  term: string,
+function buildExportRowData(
   assignments: IAssignment[],
   lookups: {
     coursesById: Map<
@@ -268,10 +304,10 @@ function buildBannerRowData(
     >
     professorsById: Map<string, { covenantId: string; displayName?: string }>
     roomsById: Map<string, { abbreviation: string; roomNumber: string }>
-    estimatedEnrollmentByKey: Map<string, number>
+    preferenceFieldsByKey: Map<string, PreferenceExportFields>
   },
-): BannerRow[] {
-  const rows: BannerRow[] = []
+): ExportRow[] {
+  const rows: ExportRow[] = []
 
   for (const assignment of assignments) {
     const catalogCourseId = catalogCourseIdOf(assignment.courseId)
@@ -282,14 +318,14 @@ function buildBannerRowData(
     )
     const room = getLookupValue(lookups.roomsById, assignment.roomId)
     const normalizedReference = normalizeCourseReference(assignment.courseId)
-    const estimatedEnrollment =
-      lookups.estimatedEnrollmentByKey.get(
+    const preferenceFields =
+      lookups.preferenceFieldsByKey.get(
         buildEnrollmentKey(
           assignment.professorId,
           normalizedReference.scheduledCourseId,
         ),
       ) ??
-      lookups.estimatedEnrollmentByKey.get(
+      lookups.preferenceFieldsByKey.get(
         buildEnrollmentKey(
           assignment.professorId,
           normalizedReference.catalogCourseId,
@@ -297,25 +333,38 @@ function buildBannerRowData(
       )
     const courseFields = fallbackCourseFields(assignment, course)
     const roomFields = fallbackRoomFields(assignment, room)
+    const roomLabel = formatExportRoomLabel(room, assignment.roomId)
 
-    const row: BannerRow = {
+    const row: ExportRow = {
       Department: courseFields.department,
-      CourseNumber: courseFields.courseNumber,
+      Course: courseFields.courseNumber,
       Section: courseSectionOf(assignment.courseId) ?? '',
       Title: courseFields.title,
       CreditHours: courseFields.creditHours,
-      ProfessorCovenantId:
-        professor?.covenantId ??
-        (looksLikeOpaqueId(assignment.professorId)
-          ? ''
-          : assignment.professorId),
+      CRN: preferenceFields?.crn ?? '',
+      CourseFee:
+        preferenceFields?.courseFee !== null &&
+        preferenceFields?.courseFee !== undefined
+          ? preferenceFields.courseFee
+          : '',
+      Instructor: formatExportProfessorLabel(professor),
+      InstructorCovenantId:
+        professor?.covenantId || assignment.professorId || '',
       Days: assignment.days ?? '',
       StartTime: assignment.startTime ?? '',
       EndTime: assignment.endTime ?? '',
-      BuildingCode: roomFields.buildingCode,
-      RoomNumber: roomFields.roomNumber,
+      Time: formatExportTimeLabel(assignment),
+      Building: roomFields.buildingCode,
+      Room: roomLabel,
       EstimatedEnrollment:
-        estimatedEnrollment !== undefined ? estimatedEnrollment : '',
+        preferenceFields?.estimatedEnrollment !== null &&
+        preferenceFields?.estimatedEnrollment !== undefined
+          ? preferenceFields.estimatedEnrollment
+          : '',
+      OverrideBy: formatExportOverrideLabel({
+        overrideBy: assignment.overrideBy,
+        professorsById: lookups.professorsById,
+      }),
     }
 
     rows.push(row)
@@ -428,7 +477,7 @@ export async function buildScheduleExportFile(
     string,
     { covenantId: string; displayName?: string }
   >()
-  const estimatedEnrollmentByKey = new Map<string, number>()
+  const preferenceFieldsByKey = new Map<string, PreferenceExportFields>()
   for (const course of courses) {
     const payload = {
       deptCode: course.deptCode,
@@ -445,6 +494,7 @@ export async function buildScheduleExportFile(
     }
     setLookupAlias(professorsById, professor._id, payload)
     setLookupAlias(professorsById, professor.covenantId, payload)
+    setLookupAlias(professorsById, professor.displayName, payload)
 
     for (const submission of professor.preferences ?? []) {
       if (submission.term !== schedule.term) continue
@@ -453,34 +503,35 @@ export async function buildScheduleExportFile(
           coursePreference.courseId,
           coursePreference.section ?? null,
         )
-        estimatedEnrollmentByKey.set(
-          buildEnrollmentKey(
-            professor._id,
-            normalizedReference.scheduledCourseId,
-          ),
-          coursePreference.expectedEnrollment,
-        )
-        estimatedEnrollmentByKey.set(
-          buildEnrollmentKey(
-            professor._id,
-            normalizedReference.catalogCourseId,
-          ),
-          coursePreference.expectedEnrollment,
-        )
-        estimatedEnrollmentByKey.set(
-          buildEnrollmentKey(
-            professor.covenantId,
-            normalizedReference.scheduledCourseId,
-          ),
-          coursePreference.expectedEnrollment,
-        )
-        estimatedEnrollmentByKey.set(
-          buildEnrollmentKey(
-            professor.covenantId,
-            normalizedReference.catalogCourseId,
-          ),
-          coursePreference.expectedEnrollment,
-        )
+        const preferencePayload: PreferenceExportFields = {
+          estimatedEnrollment: coursePreference.expectedEnrollment ?? null,
+          crn: coursePreference.crn ?? null,
+          courseFee: coursePreference.courseFee ?? null,
+        }
+
+        for (const professorKey of [
+          professor._id,
+          professor.covenantId,
+          professor.displayName,
+          coursePreference.instructor ?? '',
+        ]) {
+          if (!professorKey) continue
+
+          preferenceFieldsByKey.set(
+            buildEnrollmentKey(
+              professorKey,
+              normalizedReference.scheduledCourseId,
+            ),
+            preferencePayload,
+          )
+          preferenceFieldsByKey.set(
+            buildEnrollmentKey(
+              professorKey,
+              normalizedReference.catalogCourseId,
+            ),
+            preferencePayload,
+          )
+        }
       }
     }
   }
@@ -499,11 +550,11 @@ export async function buildScheduleExportFile(
     setLookupAlias(roomsById, room.displayName, payload)
   }
 
-  const rows = buildBannerRowData(schedule.term, schedule.assignments, {
+  const rows = buildExportRowData(schedule.assignments, {
     coursesById,
     professorsById,
     roomsById,
-    estimatedEnrollmentByKey,
+    preferenceFieldsByKey,
   })
 
   const baseFilename = `schedule_${schedule.term}_run_${schedule.runNumber}`
@@ -511,7 +562,7 @@ export async function buildScheduleExportFile(
   if (format === 'xlsx') {
     const XLSX = await loadXlsxModule()
     const worksheet = XLSX.utils.json_to_sheet(rows, {
-      header: [...bannerHeaders],
+      header: [...exportHeaders],
     })
     const workbook = XLSX.utils.book_new()
     XLSX.utils.book_append_sheet(workbook, worksheet, 'Schedule')
@@ -526,11 +577,11 @@ export async function buildScheduleExportFile(
   }
 
   const csvRows = rows.map((row) =>
-    bannerHeaders
+    exportHeaders
       .map((header) => escapeCsv(String(row[header] ?? '')))
       .join(','),
   )
-  const body = [bannerHeaders.join(','), ...csvRows].join('\n')
+  const body = [exportHeaders.join(','), ...csvRows].join('\n')
 
   return {
     body,

--- a/server/services/scheduling/scheduleExport.ts
+++ b/server/services/scheduling/scheduleExport.ts
@@ -357,10 +357,13 @@ function buildExportRowData(
       Building: roomFields.buildingCode,
       Room: roomLabel,
       EstimatedEnrollment:
-        preferenceFields?.estimatedEnrollment !== null &&
-        preferenceFields?.estimatedEnrollment !== undefined
-          ? preferenceFields.estimatedEnrollment
-          : '',
+        assignment.enrollmentOverride !== null &&
+        assignment.enrollmentOverride !== undefined
+          ? assignment.enrollmentOverride
+          : preferenceFields?.estimatedEnrollment !== null &&
+              preferenceFields?.estimatedEnrollment !== undefined
+            ? preferenceFields.estimatedEnrollment
+            : '',
       OverrideBy: formatExportOverrideLabel({
         overrideBy: assignment.overrideBy,
         professorsById: lookups.professorsById,

--- a/server/services/scheduling/scheduleRecords.ts
+++ b/server/services/scheduling/scheduleRecords.ts
@@ -285,6 +285,15 @@ function validateAssignments(assignments: unknown): string | null {
     ) {
       return `Assignment ${i}: overrideBy must be a string or null`
     }
+    if (
+      assignment.enrollmentOverride !== undefined &&
+      assignment.enrollmentOverride !== null &&
+      (typeof assignment.enrollmentOverride !== 'number' ||
+        !Number.isFinite(assignment.enrollmentOverride) ||
+        assignment.enrollmentOverride < 0)
+    ) {
+      return `Assignment ${i}: enrollmentOverride must be a non-negative number or null`
+    }
   }
 
   return null

--- a/server/services/scheduling/types.ts
+++ b/server/services/scheduling/types.ts
@@ -166,7 +166,7 @@ export interface ScheduleAssignment {
   startTime: string
   endTime: string
   enrollmentOverride?: number | null
-  overrideBy?: string
+  overrideBy?: string | null
 }
 
 export interface ScheduleConflict {

--- a/server/services/scheduling/types.ts
+++ b/server/services/scheduling/types.ts
@@ -165,6 +165,7 @@ export interface ScheduleAssignment {
   days: DayPattern
   startTime: string
   endTime: string
+  enrollmentOverride?: number | null
   overrideBy?: string
 }
 

--- a/types/schedule.ts
+++ b/types/schedule.ts
@@ -18,6 +18,7 @@ export interface ScheduleAssignment {
   days: DayPattern
   startTime: string
   endTime: string
+  enrollmentOverride?: number | null
   overrideBy?: string | null
 }
 


### PR DESCRIPTION
app/assets/css/room-viewer.css

Prevents horizontal overflow in the filter panel.
Makes the filter grid auto-fit smaller columns.
Lets labels/inputs shrink properly.
Reduces filter label and field text size slightly.
server/services/scheduling/scheduleExport.ts

Replaces the old ID-heavy export shape with readable schedule columns.
Adds CRN, CourseFee, Instructor, InstructorCovenantId, Time, Building, Room, and OverrideBy.
Pulls preference data through export lookup so enrollment, CRN, and fee follow each scheduled row.



new commit:
Added explicit widths for the main schedule columns.
Switched edit mode to readable dropdowns/selectors for course, instructor, and room.
Made dept/title/building update from the selected course/room.
Added editable section and enroll.
Added single-line cell previews for the main table.
Added shared styling for .schedule-native-input.
app/utils/schedule.ts

Uses assignment.enrollmentOverride before falling back to preference enrollment.
server/api/schedule/[term]/assignment.patch.ts

Accepts enrollmentOverride in assignment edits.
server/api/schedule/[term]/template.get.ts

Added enrollmentOverride: null to assignment examples.
server/models/index.ts

Added enrollmentOverride?: number | null to IAssignment.
Added enrollmentOverride to the Mongoose assignment schema.
server/services/scheduling/scheduleExport.ts

Export now prefers the saved assignment enrollmentOverride over preference enrollment.
server/services/scheduling/scheduleRecords.ts

Validates enrollmentOverride as a non-negative number or null.
server/services/scheduling/types.ts

Added enrollmentOverride to scheduling service assignment type.
types/schedule.ts

Added enrollmentOverride to the shared client schedule assignment type.